### PR TITLE
Add test cscope.out and tags file (related to #16)

### DIFF
--- a/test/cscope.out
+++ b/test/cscope.out
@@ -1,0 +1,1853 @@
+cscope 15 $HOME/code/codequery -c               0000013332
+	@build/CMakeFiles/3.0.1/CompilerIdC/CMakeCCompilerId.c
+
+1 #ifdef 
+__cplusplus
+
+
+8 #if 
+defined
+(
+__18CXX
+)
+
+9 #define 
+	#ID_VOID_MAIN
+
+
+	)
+
+12 #if 
+defined
+(
+__INTEL_COMPILER
+) || defined(
+__ICC
+)
+
+13 #define 
+	#COMPILER_ID
+ "Intel"
+
+	)
+
+15 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__INTEL_COMPILER
+/100)
+
+	)
+
+16 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__INTEL_COMPILER
+/10 % 10)
+
+	)
+
+17 #if 
+defined
+(
+__INTEL_COMPILER_UPDATE
+)
+
+18 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__INTEL_COMPILER_UPDATE
+)
+
+	)
+
+20 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__INTEL_COMPILER
+ % 10)
+
+	)
+
+22 #if 
+defined
+(
+__INTEL_COMPILER_BUILD_DATE
+)
+
+24 #define 
+	#COMPILER_VERSION_TWEAK
+ 
+	`DEC
+(
+__INTEL_COMPILER_BUILD_DATE
+)
+
+	)
+
+26 #if 
+defined
+(
+_MSC_VER
+)
+
+27 #define 
+	#SIMULATE_ID
+ "MSVC"
+
+	)
+
+29 #define 
+	#SIMULATE_VERSION_MAJOR
+ 
+	`DEC
+(
+_MSC_VER
+ / 100)
+
+	)
+
+30 #define 
+	#SIMULATE_VERSION_MINOR
+ 
+	`DEC
+(
+_MSC_VER
+ % 100)
+
+	)
+
+33 #elif 
+defined
+(
+__PATHCC__
+)
+
+34 #define 
+	#COMPILER_ID
+ "PathScale"
+
+	)
+
+35 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__PATHCC__
+)
+
+	)
+
+36 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__PATHCC_MINOR__
+)
+
+	)
+
+37 #if 
+defined
+(
+__PATHCC_PATCHLEVEL__
+)
+
+38 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__PATHCC_PATCHLEVEL__
+)
+
+	)
+
+41 #elif 
+defined
+(
+__clang__
+)
+
+42 #if 
+defined
+(
+__apple_build_version__
+)
+
+43 #define 
+	#COMPILER_ID
+ "AppleClang"
+
+	)
+
+44 #define 
+	#COMPILER_VERSION_TWEAK
+ 
+	`DEC
+(
+__apple_build_version__
+)
+
+	)
+
+46 #define 
+	#COMPILER_ID
+ "Clang"
+
+	)
+
+48 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__clang_major__
+)
+
+	)
+
+49 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__clang_minor__
+)
+
+	)
+
+50 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__clang_patchlevel__
+)
+
+	)
+
+51 #if 
+defined
+(
+_MSC_VER
+)
+
+52 #define 
+	#SIMULATE_ID
+ "MSVC"
+
+	)
+
+54 #define 
+	#SIMULATE_VERSION_MAJOR
+ 
+	`DEC
+(
+_MSC_VER
+ / 100)
+
+	)
+
+55 #define 
+	#SIMULATE_VERSION_MINOR
+ 
+	`DEC
+(
+_MSC_VER
+ % 100)
+
+	)
+
+58 #elif 
+defined
+(
+__BORLANDC__
+) && defined(
+__CODEGEARC_VERSION__
+)
+
+59 #define 
+	#COMPILER_ID
+ "Embarcadero"
+
+	)
+
+60 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`HEX
+(
+__CODEGEARC_VERSION__
+>>24 & 0x00FF)
+
+	)
+
+61 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`HEX
+(
+__CODEGEARC_VERSION__
+>>16 & 0x00FF)
+
+	)
+
+62 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`HEX
+(
+__CODEGEARC_VERSION__
+ & 0xFFFF)
+
+	)
+
+64 #elif 
+defined
+(
+__BORLANDC__
+)
+
+65 #define 
+	#COMPILER_ID
+ "Borland"
+
+	)
+
+67 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`HEX
+(
+__BORLANDC__
+>>8)
+
+	)
+
+68 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`HEX
+(
+__BORLANDC__
+ & 0xFF)
+
+	)
+
+70 #elif 
+defined
+(
+__WATCOMC__
+)
+
+71 #define 
+	#COMPILER_ID
+ "Watcom"
+
+	)
+
+73 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__WATCOMC__
+ / 100)
+
+	)
+
+74 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__WATCOMC__
+ % 100)
+
+	)
+
+76 #elif 
+defined
+(
+__SUNPRO_C
+)
+
+77 #define 
+	#COMPILER_ID
+ "SunPro"
+
+	)
+
+78 #if 
+__SUNPRO_C
+ >= 0x5100
+
+80 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`HEX
+(
+__SUNPRO_C
+>>12)
+
+	)
+
+81 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`HEX
+(
+__SUNPRO_C
+>>4 & 0xFF)
+
+	)
+
+82 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`HEX
+(
+__SUNPRO_C
+ & 0xF)
+
+	)
+
+85 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`HEX
+(
+__SUNPRO_C
+>>8)
+
+	)
+
+86 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`HEX
+(
+__SUNPRO_C
+>>4 & 0xF)
+
+	)
+
+87 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`HEX
+(
+__SUNPRO_C
+ & 0xF)
+
+	)
+
+90 #elif 
+defined
+(
+__HP_cc
+)
+
+91 #define 
+	#COMPILER_ID
+ "HP"
+
+	)
+
+93 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__HP_cc
+/10000)
+
+	)
+
+94 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__HP_cc
+/100 % 100)
+
+	)
+
+95 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__HP_cc
+ % 100)
+
+	)
+
+97 #elif 
+defined
+(
+__DECC
+)
+
+98 #define 
+	#COMPILER_ID
+ "Compaq"
+
+	)
+
+100 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__DECC_VER
+/10000000)
+
+	)
+
+101 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__DECC_VER
+/100000 % 100)
+
+	)
+
+102 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__DECC_VER
+ % 10000)
+
+	)
+
+104 #elif 
+defined
+(
+__IBMC__
+)
+
+105 #if 
+defined
+(
+__COMPILER_VER__
+)
+
+106 #define 
+	#COMPILER_ID
+ "zOS"
+
+	)
+
+108 #if 
+__IBMC__
+ >= 800
+
+109 #define 
+	#COMPILER_ID
+ "XL"
+
+	)
+
+111 #define 
+	#COMPILER_ID
+ "VisualAge"
+
+	)
+
+114 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__IBMC__
+/100)
+
+	)
+
+115 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__IBMC__
+/10 % 10)
+
+	)
+
+116 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__IBMC__
+ % 10)
+
+	)
+
+119 #elif 
+defined
+(
+__PGI
+)
+
+120 #define 
+	#COMPILER_ID
+ "PGI"
+
+	)
+
+121 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__PGIC__
+)
+
+	)
+
+122 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__PGIC_MINOR__
+)
+
+	)
+
+123 #if 
+defined
+(
+__PGIC_PATCHLEVEL__
+)
+
+124 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__PGIC_PATCHLEVEL__
+)
+
+	)
+
+127 #elif 
+defined
+(
+_CRAYC
+)
+
+128 #define 
+	#COMPILER_ID
+ "Cray"
+
+	)
+
+129 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+_RELEASE
+)
+
+	)
+
+130 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+_RELEASE_MINOR
+)
+
+	)
+
+132 #elif 
+defined
+(
+__TI_COMPILER_VERSION__
+)
+
+133 #define 
+	#COMPILER_ID
+ "TI"
+
+	)
+
+135 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__TI_COMPILER_VERSION__
+/1000000)
+
+	)
+
+136 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__TI_COMPILER_VERSION__
+/1000 % 1000)
+
+	)
+
+137 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__TI_COMPILER_VERSION__
+ % 1000)
+
+	)
+
+139 #elif 
+defined
+(
+__TINYC__
+)
+
+140 #define 
+	#COMPILER_ID
+ "TinyCC"
+
+	)
+
+142 #elif 
+defined
+(
+__SCO_VERSION__
+)
+
+143 #define 
+	#COMPILER_ID
+ "SCO"
+
+	)
+
+145 #elif 
+defined
+(
+__GNUC__
+)
+
+146 #define 
+	#COMPILER_ID
+ "GNU"
+
+	)
+
+147 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+__GNUC__
+)
+
+	)
+
+148 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+__GNUC_MINOR__
+)
+
+	)
+
+149 #if 
+defined
+(
+__GNUC_PATCHLEVEL__
+)
+
+150 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+__GNUC_PATCHLEVEL__
+)
+
+	)
+
+153 #elif 
+defined
+(
+_MSC_VER
+)
+
+154 #define 
+	#COMPILER_ID
+ "MSVC"
+
+	)
+
+156 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+_MSC_VER
+ / 100)
+
+	)
+
+157 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+_MSC_VER
+ % 100)
+
+	)
+
+158 #if 
+defined
+(
+_MSC_FULL_VER
+)
+
+159 #if 
+_MSC_VER
+ >= 1400
+
+161 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+_MSC_FULL_VER
+ % 100000)
+
+	)
+
+164 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+_MSC_FULL_VER
+ % 10000)
+
+	)
+
+167 #if 
+defined
+(
+_MSC_BUILD
+)
+
+168 #define 
+	#COMPILER_VERSION_TWEAK
+ 
+	`DEC
+(
+_MSC_BUILD
+)
+
+	)
+
+172 #elif 
+defined
+(
+__VISUALDSPVERSION__
+)
+
+173 #define 
+	#COMPILER_ID
+ "ADSP"
+
+	)
+
+175 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`HEX
+(
+__VISUALDSPVERSION__
+>>24)
+
+	)
+
+176 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`HEX
+(
+__VISUALDSPVERSION__
+>>16 & 0xFF)
+
+	)
+
+177 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`HEX
+(
+__VISUALDSPVERSION__
+>>8 & 0xFF)
+
+	)
+
+180 #elif 
+defined
+(
+__ADSPBLACKFIN__
+) || defined(
+__ADSPTS__
+) || defined(
+__ADSP21000__
+)
+
+181 #define 
+	#COMPILER_ID
+ "ADSP"
+
+	)
+
+185 #elif 
+defined
+(
+__IAR_SYSTEMS_ICC__
+ ) || defined(
+__IAR_SYSTEMS_ICC
+)
+
+186 #define 
+	#COMPILER_ID
+ "IAR"
+
+	)
+
+190 #elif 
+defined
+(
+SDCC
+)
+
+191 #define 
+	#COMPILER_ID
+ "SDCC"
+
+	)
+
+193 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+SDCC
+/100)
+
+	)
+
+194 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+SDCC
+/10 % 10)
+
+	)
+
+195 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+SDCC
+ % 10)
+
+	)
+
+197 #elif 
+defined
+(
+_SGI_COMPILER_VERSION
+) || defined(
+_COMPILER_VERSION
+)
+
+198 #define 
+	#COMPILER_ID
+ "MIPSpro"
+
+	)
+
+199 #if 
+defined
+(
+_SGI_COMPILER_VERSION
+)
+
+201 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+_SGI_COMPILER_VERSION
+/100)
+
+	)
+
+202 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+_SGI_COMPILER_VERSION
+/10 % 10)
+
+	)
+
+203 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+_SGI_COMPILER_VERSION
+ % 10)
+
+	)
+
+206 #define 
+	#COMPILER_VERSION_MAJOR
+ 
+	`DEC
+(
+_COMPILER_VERSION
+/100)
+
+	)
+
+207 #define 
+	#COMPILER_VERSION_MINOR
+ 
+	`DEC
+(
+_COMPILER_VERSION
+/10 % 10)
+
+	)
+
+208 #define 
+	#COMPILER_VERSION_PATCH
+ 
+	`DEC
+(
+_COMPILER_VERSION
+ % 10)
+
+	)
+
+214 #elif 
+defined
+(
+__sgi
+)
+
+215 #define 
+	#COMPILER_ID
+ "MIPSpro"
+
+	)
+
+217 #elif 
+defined
+(
+__hpux
+) || defined(
+__hpua
+)
+
+218 #define 
+	#COMPILER_ID
+ "HP"
+
+	)
+
+221 #define 
+	#COMPILER_ID
+ ""
+
+	)
+
+229 char const* 
+	ginfo_compiler
+ = "INFO" ":" "compiler[" 
+COMPILER_ID
+ "]";
+
+230 #ifdef 
+SIMULATE_ID
+
+
+231 char const* 
+	ginfo_simulate
+ = "INFO" ":" "simulate[" 
+SIMULATE_ID
+ "]";
+
+234 #ifdef 
+__QNXNTO__
+
+
+235 char const* 
+	gqnxnto
+ = "INFO" ":" "qnxnto";
+
+239 #if 
+defined
+(
+__linux
+) || defined(
+__linux__
+) || defined(
+linux
+)
+
+240 #define 
+	#PLATFORM_ID
+ "Linux"
+
+	)
+
+242 #elif 
+defined
+(
+__CYGWIN__
+)
+
+243 #define 
+	#PLATFORM_ID
+ "Cygwin"
+
+	)
+
+245 #elif 
+defined
+(
+__MINGW32__
+)
+
+246 #define 
+	#PLATFORM_ID
+ "MinGW"
+
+	)
+
+248 #elif 
+defined
+(
+__APPLE__
+)
+
+249 #define 
+	#PLATFORM_ID
+ "Darwin"
+
+	)
+
+251 #elif 
+defined
+(
+_WIN32
+) || defined(
+__WIN32__
+) || defined(
+WIN32
+)
+
+252 #define 
+	#PLATFORM_ID
+ "Windows"
+
+	)
+
+254 #elif 
+defined
+(
+__FreeBSD__
+) || defined(
+__FreeBSD
+)
+
+255 #define 
+	#PLATFORM_ID
+ "FreeBSD"
+
+	)
+
+257 #elif 
+defined
+(
+__NetBSD__
+) || defined(
+__NetBSD
+)
+
+258 #define 
+	#PLATFORM_ID
+ "NetBSD"
+
+	)
+
+260 #elif 
+defined
+(
+__OpenBSD__
+) || defined(
+__OPENBSD
+)
+
+261 #define 
+	#PLATFORM_ID
+ "OpenBSD"
+
+	)
+
+263 #elif 
+defined
+(
+__sun
+) || defined(
+sun
+)
+
+264 #define 
+	#PLATFORM_ID
+ "SunOS"
+
+	)
+
+266 #elif 
+defined
+(
+_AIX
+) || defined(
+__AIX
+) || defined(
+__AIX__
+) || defined(
+__aix
+) || defined(
+__aix__
+)
+
+267 #define 
+	#PLATFORM_ID
+ "AIX"
+
+	)
+
+269 #elif 
+defined
+(
+__sgi
+) || defined(
+__sgi__
+) || defined(
+_SGI
+)
+
+270 #define 
+	#PLATFORM_ID
+ "IRIX"
+
+	)
+
+272 #elif 
+defined
+(
+__hpux
+) || defined(
+__hpux__
+)
+
+273 #define 
+	#PLATFORM_ID
+ "HP-UX"
+
+	)
+
+275 #elif 
+defined
+(
+__HAIKU__
+)
+
+276 #define 
+	#PLATFORM_ID
+ "Haiku"
+
+	)
+
+278 #elif 
+defined
+(
+__BeOS
+) || defined(
+__BEOS__
+) || defined(
+_BEOS
+)
+
+279 #define 
+	#PLATFORM_ID
+ "BeOS"
+
+	)
+
+281 #elif 
+defined
+(
+__QNX__
+) || defined(
+__QNXNTO__
+)
+
+282 #define 
+	#PLATFORM_ID
+ "QNX"
+
+	)
+
+284 #elif 
+defined
+(
+__tru64
+) || defined(
+_tru64
+) || defined(
+__TRU64__
+)
+
+285 #define 
+	#PLATFORM_ID
+ "Tru64"
+
+	)
+
+287 #elif 
+defined
+(
+__riscos
+) || defined(
+__riscos__
+)
+
+288 #define 
+	#PLATFORM_ID
+ "RISCos"
+
+	)
+
+290 #elif 
+defined
+(
+__sinix
+) || defined(
+__sinix__
+) || defined(
+__SINIX__
+)
+
+291 #define 
+	#PLATFORM_ID
+ "SINIX"
+
+	)
+
+293 #elif 
+defined
+(
+__UNIX_SV__
+)
+
+294 #define 
+	#PLATFORM_ID
+ "UNIX_SV"
+
+	)
+
+296 #elif 
+defined
+(
+__bsdos__
+)
+
+297 #define 
+	#PLATFORM_ID
+ "BSDOS"
+
+	)
+
+299 #elif 
+defined
+(
+_MPRAS
+) || defined(
+MPRAS
+)
+
+300 #define 
+	#PLATFORM_ID
+ "MP-RAS"
+
+	)
+
+302 #elif 
+defined
+(
+__osf
+) || defined(
+__osf__
+)
+
+303 #define 
+	#PLATFORM_ID
+ "OSF1"
+
+	)
+
+305 #elif 
+defined
+(
+_SCO_SV
+) || defined(
+SCO_SV
+) || defined(
+sco_sv
+)
+
+306 #define 
+	#PLATFORM_ID
+ "SCO_SV"
+
+	)
+
+308 #elif 
+defined
+(
+__ultrix
+) || defined(
+__ultrix__
+) || defined(
+_ULTRIX
+)
+
+309 #define 
+	#PLATFORM_ID
+ "ULTRIX"
+
+	)
+
+311 #elif 
+defined
+(
+__XENIX__
+) || defined(
+_XENIX
+) || defined(
+XENIX
+)
+
+312 #define 
+	#PLATFORM_ID
+ "Xenix"
+
+	)
+
+315 #define 
+	#PLATFORM_ID
+ ""
+
+	)
+
+324 #if 
+defined
+(
+_WIN32
+) && defined(
+_MSC_VER
+)
+
+325 #if 
+defined
+(
+_M_IA64
+)
+
+326 #define 
+	#ARCHITECTURE_ID
+ "IA64"
+
+	)
+
+328 #elif 
+defined
+(
+_M_X64
+) || defined(
+_M_AMD64
+)
+
+329 #define 
+	#ARCHITECTURE_ID
+ "x64"
+
+	)
+
+331 #elif 
+defined
+(
+_M_IX86
+)
+
+332 #define 
+	#ARCHITECTURE_ID
+ "X86"
+
+	)
+
+334 #elif 
+defined
+(
+_M_ARM
+)
+
+335 #define 
+	#ARCHITECTURE_ID
+ "ARM"
+
+	)
+
+337 #elif 
+defined
+(
+_M_MIPS
+)
+
+338 #define 
+	#ARCHITECTURE_ID
+ "MIPS"
+
+	)
+
+340 #elif 
+defined
+(
+_M_SH
+)
+
+341 #define 
+	#ARCHITECTURE_ID
+ "SHx"
+
+	)
+
+344 #define 
+	#ARCHITECTURE_ID
+ ""
+
+	)
+
+348 #define 
+	#ARCHITECTURE_ID
+ ""
+
+	)
+
+352 #define 
+	#DEC
+(
+n
+) \
+
+353 ('0' + (((
+n
+) / 10000000)%10)), \
+
+354 ('0' + (((
+n
+) / 1000000)%10)), \
+
+355 ('0' + (((
+n
+) / 100000)%10)), \
+
+356 ('0' + (((
+n
+) / 10000)%10)), \
+
+357 ('0' + (((
+n
+) / 1000)%10)), \
+
+358 ('0' + (((
+n
+) / 100)%10)), \
+
+359 ('0' + (((
+n
+) / 10)%10)), \
+
+360 ('0' + ((
+n
+) % 10))
+
+	)
+
+363 #define 
+	#HEX
+(
+n
+) \
+
+364 ('0' + ((
+n
+)>>28 & 0xF)), \
+
+365 ('0' + ((
+n
+)>>24 & 0xF)), \
+
+366 ('0' + ((
+n
+)>>20 & 0xF)), \
+
+367 ('0' + ((
+n
+)>>16 & 0xF)), \
+
+368 ('0' + ((
+n
+)>>12 & 0xF)), \
+
+369 ('0' + ((
+n
+)>>8 & 0xF)), \
+
+370 ('0' + ((
+n
+)>>4 & 0xF)), \
+
+371 ('0' + ((
+n
+) & 0xF))
+
+	)
+
+374 #ifdef 
+COMPILER_VERSION_MAJOR
+
+
+375 char const 
+	ginfo_version
+[] = {
+
+378 
+COMPILER_VERSION_MAJOR
+,
+
+379 #ifdef 
+COMPILER_VERSION_MINOR
+
+
+380 '.', 
+COMPILER_VERSION_MINOR
+,
+
+381 #ifdef 
+COMPILER_VERSION_PATCH
+
+
+382 '.', 
+COMPILER_VERSION_PATCH
+,
+
+383 #ifdef 
+COMPILER_VERSION_TWEAK
+
+
+384 '.', 
+COMPILER_VERSION_TWEAK
+,
+
+392 #ifdef 
+SIMULATE_VERSION_MAJOR
+
+
+393 char const 
+	ginfo_simulate_version
+[] = {
+
+396 
+SIMULATE_VERSION_MAJOR
+,
+
+397 #ifdef 
+SIMULATE_VERSION_MINOR
+
+
+398 '.', 
+SIMULATE_VERSION_MINOR
+,
+
+399 #ifdef 
+SIMULATE_VERSION_PATCH
+
+
+400 '.', 
+SIMULATE_VERSION_PATCH
+,
+
+401 #ifdef 
+SIMULATE_VERSION_TWEAK
+
+
+402 '.', 
+SIMULATE_VERSION_TWEAK
+,
+
+413 char const* 
+	ginfo_platform
+ = "INFO" ":" "platform[" 
+PLATFORM_ID
+ "]";
+
+414 char const* 
+	ginfo_arch
+ = "INFO" ":" "arch[" 
+ARCHITECTURE_ID
+ "]";
+
+421 #ifdef 
+ID_VOID_MAIN
+
+
+422 void 
+	$main
+() {
+	}
+}
+
+424 int 
+	$main
+(int 
+argc
+, char* 
+argv
+[])
+
+426 int 
+require
+ = 0;
+
+427 
+require
+ += 
+info_compiler
+[
+argc
+];
+
+428 
+require
+ += 
+info_platform
+[
+argc
+];
+
+429 
+require
+ += 
+info_arch
+[
+argc
+];
+
+430 #ifdef 
+COMPILER_VERSION_MAJOR
+
+
+431 
+require
+ += 
+info_version
+[
+argc
+];
+
+433 #ifdef 
+SIMULATE_ID
+
+
+434 
+require
+ += 
+info_simulate
+[
+argc
+];
+
+436 #ifdef 
+SIMULATE_VERSION_MAJOR
+
+
+437 
+require
+ += 
+info_simulate_version
+[
+argc
+];
+
+439 (void)
+argv
+;
+
+440 return 
+require
+;
+
+441 
+	}
+}
+
+	@
+1
+.
+1
+/usr/include
+1
+54
+build/CMakeFiles/3.0.1/CompilerIdC/CMakeCCompilerId.c

--- a/test/tags
+++ b/test/tags
@@ -1,0 +1,2180 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+ABOUTDIALOG_H_CQ	gui/aboutdialog.h	/^#define ABOUTDIALOG_H_CQ$/;"	d
+AEdge	showgraph/Graph/agraph.h	/^class AEdge: public Edge$/;"	c
+AEdge	showgraph/Graph/agraph.h	/^inline AEdge::AEdge( AGraph *graph_p, int _id, ANode *_pred, ANode* _succ):$/;"	f	class:AEdge
+AGRAPH_H	showgraph/Graph/agraph.h	/^#define AGRAPH_H$/;"	d
+AGraph	showgraph/Graph/agraph.h	/^    AGraph( bool create_pools): Graph( false)$/;"	f	class:AGraph
+AGraph	showgraph/Graph/agraph.h	/^class AGraph: public Graph$/;"	c
+ANode	showgraph/Graph/agraph.h	/^class ANode: public Node$/;"	c
+ANode	showgraph/Graph/agraph.h	/^inline ANode::ANode( AGraph *graph_p, int _id):$/;"	f	class:ANode
+ASRT_H	showgraph/Utils/asrt.h	/^#define ASRT_H$/;"	d
+ASSERT	showgraph/Utils/asrt.h	/^#  define ASSERT(/;"	d
+ASSERTD	showgraph/Utils/asrt.h	/^#    define ASSERTD(/;"	d
+ASSERT_XD	showgraph/Utils/asrt.h	/^#    define ASSERT_XD(/;"	d
+AUX_EDGE_CONTROL	showgraph/Layout/aux_node.h	/^    AUX_EDGE_CONTROL,$/;"	e	enum:AuxNodeType
+AUX_EDGE_H	showgraph/Layout/aux_edge.h	/^#define AUX_EDGE_H$/;"	d
+AUX_EDGE_LABEL	showgraph/Layout/aux_node.h	/^    AUX_EDGE_LABEL,$/;"	e	enum:AuxNodeType
+AUX_GRAPH_H	showgraph/Layout/aux_graph.h	/^#define AUX_GRAPH_H$/;"	d
+AUX_NODE_H	showgraph/Layout/aux_node.h	/^#define AUX_NODE_H$/;"	d
+AUX_NODE_SIMPLE	showgraph/Layout/aux_node.h	/^    AUX_NODE_SIMPLE,$/;"	e	enum:AuxNodeType
+AUX_NODE_TYPES_NUM	showgraph/Layout/aux_node.h	/^    AUX_NODE_TYPES_NUM$/;"	e	enum:AuxNodeType
+AbleToCopy	gui/fileviewer.cpp	/^void fileviewer::AbleToCopy(bool copy)$/;"	f	class:fileviewer
+AboutQtTriggered	gui/mainwindow.cpp	/^void mainwindow::AboutQtTriggered(bool checked)$/;"	f	class:mainwindow
+AboutTriggered	gui/mainwindow.cpp	/^void mainwindow::AboutTriggered(bool checked)$/;"	f	class:mainwindow
+AddEdgeInDir	showgraph/Graph/agraph.h	/^ANode::AddEdgeInDir( AEdge *edge, GraphDir dir)$/;"	f	class:ANode
+AddEdgeInDir	showgraph/Graph/node_inline.h	/^Node::AddEdgeInDir( Edge *edge, GraphDir dir)$/;"	f	class:Node
+AddEdgeInDir	showgraph/GraphView/node_item.h	/^    inline void AddEdgeInDir( GEdge *edge, GraphDir dir)$/;"	f	class:GNode
+AddEdgeInDir	showgraph/Layout/aux_graph.h	/^AuxNode::AddEdgeInDir( AuxEdge *edge, GraphDir dir)$/;"	f	class:AuxNode
+AddPred	showgraph/Graph/agraph.h	/^ANode::AddPred( AEdge *edge)$/;"	f	class:ANode
+AddPred	showgraph/Graph/node_inline.h	/^inline void Node::AddPred( Edge *edge)$/;"	f	class:Node
+AddPred	showgraph/GraphView/node_item.h	/^    inline void AddPred( GEdge *edge)$/;"	f	class:GNode
+AddPred	showgraph/Layout/aux_graph.h	/^AuxNode::AddPred( AuxEdge *edge)$/;"	f	class:AuxNode
+AddSucc	showgraph/Graph/agraph.h	/^ANode::AddSucc( AEdge *edge) $/;"	f	class:ANode
+AddSucc	showgraph/Graph/node_inline.h	/^inline void Node::AddSucc( Edge *edge) $/;"	f	class:Node
+AddSucc	showgraph/GraphView/node_item.h	/^    inline void AddSucc( GEdge *edge) $/;"	f	class:GNode
+AddSucc	showgraph/Layout/aux_graph.h	/^AuxNode::AddSucc( AuxEdge *edge) $/;"	f	class:AuxNode
+Attach	showgraph/Utils/list.h	/^    inline void Attach( ListItem<Data>* peer)$/;"	f	class:ListItem
+AttachInDir	showgraph/Utils/list.h	/^    inline void AttachInDir( ListItem<Data>* p, ListDir dir)$/;"	f	class:ListItem
+AuxEdge	showgraph/Layout/aux_edge.h	/^class AuxEdge: public Edge$/;"	c
+AuxEdge	showgraph/Layout/aux_graph.h	/^inline AuxEdge::AuxEdge( AuxGraph *graph_p, int _id, AuxNode *_pred, AuxNode* _succ):$/;"	f	class:AuxEdge
+AuxEdgeType	showgraph/Layout/aux_edge.h	/^enum AuxEdgeType$/;"	g
+AuxGraph	showgraph/Layout/aux_graph.cpp	/^AuxGraph::AuxGraph( bool create_pools):$/;"	f	class:AuxGraph
+AuxGraph	showgraph/Layout/aux_graph.h	/^class AuxGraph: public QObject, public Graph$/;"	c
+AuxNode	showgraph/Layout/aux_graph.h	/^inline AuxNode::AuxNode( AuxGraph *graph_p, int _id):$/;"	f	class:AuxNode
+AuxNode	showgraph/Layout/aux_node.h	/^class AuxNode: public Node$/;"	c
+AuxNodeType	showgraph/Layout/aux_node.h	/^enum AuxNodeType$/;"	g
+B	showgraph/Utils/list_utest.cpp	/^class B: public MListIface< B, classA, LISTS_NUM>$/;"	c	file:
+BACK_EDGE	showgraph/Layout/aux_edge.h	/^	BACK_EDGE,$/;"	e	enum:AuxEdgeType
+BASE_LANG_PATH	gui/langtable.cpp	/^#define BASE_LANG_PATH /;"	d	file:
+BLURB	gui/obsolete/highlighter.cpp	/^#define BLURB /;"	d	file:
+BOTTOM_SECTOR	showgraph/GraphView/navigation.h	/^    BOTTOM_SECTOR,$/;"	e	enum:NavSector
+CHECK_CHUNKS	showgraph/Utils/mem.h	/^#  define CHECK_CHUNKS$/;"	d
+CHECK_CHUNKS	showgraph/Utils/mem.h	/^#undef CHECK_CHUNKS$/;"	d
+CHECK_DELETE	showgraph/Utils/mem.h	/^#  define CHECK_DELETE$/;"	d
+CHECK_DELETE	showgraph/Utils/mem.h	/^#undef CHECK_DELETE$/;"	d
+CHECK_ENTRY	showgraph/Utils/mem.h	/^#  define CHECK_ENTRY$/;"	d
+CHECK_ENTRY	showgraph/Utils/mem.h	/^#undef CHECK_ENTRY$/;"	d
+CHUNK_LISTS_NUM	showgraph/Utils/mem_chunk.h	/^        CHUNK_LISTS_NUM$/;"	e	enum:MemImpl::ChunkListType
+CHUNK_LIST_ALL	showgraph/Utils/mem_chunk.h	/^        CHUNK_LIST_ALL,$/;"	e	enum:MemImpl::ChunkListType
+CHUNK_LIST_FREE	showgraph/Utils/mem_chunk.h	/^        CHUNK_LIST_FREE,$/;"	e	enum:MemImpl::ChunkListType
+CHUNK_SIZE	showgraph/Utils/mem_fixed_pool.h	/^        static const size_t CHUNK_SIZE = sizeof( MemImpl::Chunk< Data>) $/;"	m	class:Mem::FixedPool
+CODEEDITOR_H	gui/obsolete/CodeEditor.h	/^ #define CODEEDITOR_H$/;"	d
+CODEQUERY_SW_LICENSE	makedb/swver.h	/^#define CODEQUERY_SW_LICENSE /;"	d
+CODEQUERY_SW_LICENSE_PARA	makedb/swver.h	/^#define CODEQUERY_SW_LICENSE_PARA /;"	d
+CODEQUERY_SW_LICENSE_PARA_LINK	makedb/swver.h	/^#define CODEQUERY_SW_LICENSE_PARA_LINK /;"	d
+CODEQUERY_SW_VERSION	makedb/swver.h	/^#define CODEQUERY_SW_VERSION /;"	d
+CODEQUERY_SW_VERSION_WEBSITE	makedb/swver.h	/^#define CODEQUERY_SW_VERSION_WEBSITE /;"	d
+CONF_H	showgraph/Utils/conf.h	/^#define CONF_H$/;"	d
+CONTEXT_VIEW	showgraph/GraphView/graph_view.h	/^    CONTEXT_VIEW,$/;"	e	enum:GraphViewMode
+CONTROL_CONTROL_MARGIN	showgraph/Layout/layout_iface.h	/^const qreal CONTROL_CONTROL_MARGIN = 5;$/;"	v
+CORE_IFFACE_H	showgraph/core_iface.h	/^#define CORE_IFFACE_H$/;"	d
+CS2SQ_H_CQ	makedb/cs2sq.h	/^#define CS2SQ_H_CQ$/;"	d
+CSCOMMON_H_CQ	makedb/cscommon.h	/^#define CSCOMMON_H_CQ$/;"	d
+CSClass	makedb/cscommon.h	/^#define CSClass	/;"	d
+CSDBHEADER_H	makedb/csdbheader.h	/^#define CSDBHEADER_H$/;"	d
+CSDBPARSER_H_CQ	makedb/csdbparser.h	/^#define CSDBPARSER_H_CQ$/;"	d
+CSDBP_GENERAL_CHK	makedb/csdbparser.cpp	/^#define CSDBP_GENERAL_CHK(/;"	d	file:
+CSDBP_MINIM_BUFSIZE	makedb/csdbparser.h	/^#define CSDBP_MINIM_BUFSIZE /;"	d
+CSDBP_SUPPORTED_VER	makedb/csdbparser.h	/^#define CSDBP_SUPPORTED_VER /;"	d
+CSDBP_SUPPORTED_VER_NUM	makedb/csdbparser.h	/^#define CSDBP_SUPPORTED_VER_NUM /;"	d
+CSDBP_SUP_PARAM	makedb/csdbparser.h	/^#define CSDBP_SUP_PARAM /;"	d
+CSDBP_SUP_PARAM2	makedb/csdbparser.h	/^#define CSDBP_SUP_PARAM2 /;"	d
+CSDirectAssgnIncrDecr	makedb/cscommon.h	/^#define CSDirectAssgnIncrDecr	/;"	d
+CSEnum	makedb/cscommon.h	/^#define CSEnum	/;"	d
+CSFile	makedb/cscommon.h	/^#define CSFile	/;"	d
+CSFuncCall	makedb/cscommon.h	/^#define CSFuncCall	/;"	d
+CSFuncDef	makedb/cscommon.h	/^#define CSFuncDef	/;"	d
+CSFuncParam	makedb/cscommon.h	/^#define CSFuncParam	/;"	d
+CSGlobalEnumStructUnion	makedb/cscommon.h	/^#define CSGlobalEnumStructUnion	/;"	d
+CSInclude	makedb/cscommon.h	/^#define CSInclude	/;"	d
+CSLocalFuncBlockDef	makedb/cscommon.h	/^#define CSLocalFuncBlockDef	/;"	d
+CSMacroDef	makedb/cscommon.h	/^#define CSMacroDef	/;"	d
+CSNoType	makedb/cscommon.h	/^#define CSNoType	/;"	d
+CSOtherGlobal	makedb/cscommon.h	/^#define CSOtherGlobal	/;"	d
+CSStruct	makedb/cscommon.h	/^#define CSStruct	/;"	d
+CSTypeDef	makedb/cscommon.h	/^#define CSTypeDef	/;"	d
+CSUnion	makedb/cscommon.h	/^#define CSUnion	/;"	d
+CTAGREAD_H_CQ	makedb/ctagread.h	/^#define CTAGREAD_H_CQ$/;"	d
+CUSTOMWIDGETPLUGIN_H	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.h	/^ #define CUSTOMWIDGETPLUGIN_H$/;"	d
+Chunk	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::Chunk()$/;"	f	class:MemImpl::Chunk
+Chunk	showgraph/Utils/mem_chunk.h	/^    template<class Data> class Chunk: $/;"	c	namespace:MemImpl
+ChunkListType	showgraph/Utils/mem_chunk.h	/^    enum ChunkListType$/;"	g	namespace:MemImpl
+ChunkPos	showgraph/Utils/mem.h	/^    typedef quint8 ChunkPos;$/;"	t	namespace:MemImpl
+ClipSearch_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::ClipSearch_ButtonClick(bool checked)$/;"	f	class:searchhandler
+CodeEditor	gui/obsolete/CodeEditor.cpp	/^ CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent)$/;"	f	class:CodeEditor
+CodeEditor	gui/obsolete/CodeEditor.h	/^ class CodeEditor : public QPlainTextEdit$/;"	c
+CodeEditorWidgetPlugin	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ CodeEditorWidgetPlugin::CodeEditorWidgetPlugin(QObject *parent)$/;"	f	class:CodeEditorWidgetPlugin
+CodeEditorWidgetPlugin	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.h	/^ class CodeEditorWidgetPlugin : public QObject, public QDesignerCustomWidgetInterface$/;"	c
+ColorButton	showgraph/GraphView/style_edit.cpp	/^ColorButton::ColorButton( QWidget *parent):$/;"	f	class:ColorButton
+ColorButton	showgraph/GraphView/style_edit.h	/^class ColorButton: public QAbstractButton$/;"	c
+Conf	showgraph/Utils/conf.cpp	/^Conf::Conf(): short_opts(), long_opts(), unknown_options()$/;"	f	class:Conf
+Conf	showgraph/Utils/conf.h	/^class Conf$/;"	c
+DIM	querylib/small_lib.h	/^#define DIM(/;"	d
+DIRSEP	querylib/small_lib.h	/^#define DIRSEP /;"	d
+Detach	showgraph/Utils/list.h	/^    inline void Detach()$/;"	f	class:ListItem
+DfsStepInfo	showgraph/Layout/layout.cpp	/^    DfsStepInfo( AuxNode *n)$/;"	f	struct:DfsStepInfo
+DfsStepInfo	showgraph/Layout/layout.cpp	/^struct DfsStepInfo$/;"	s	file:
+Down_ButtonClick	gui/listhandler.cpp	/^void listhandler::Down_ButtonClick(bool checked)$/;"	f	class:listhandler
+EDGE_CONTROL_HEIGHT	showgraph/Layout/layout_iface.h	/^const qreal EDGE_CONTROL_HEIGHT = 5;$/;"	v
+EDGE_CONTROL_WIDTH	showgraph/Layout/layout_iface.h	/^const qreal EDGE_CONTROL_WIDTH = 5;$/;"	v
+EDGE_H	showgraph/Graph/edge.h	/^#define EDGE_H$/;"	d
+EDGE_HELPER_H	showgraph/GraphView/edge_helper.h	/^#define EDGE_HELPER_H$/;"	d
+EDGE_INLINE_H	showgraph/Graph/edge_inline.h	/^#define EDGE_INLINE_H$/;"	d
+EDGE_LISTS_NUM	showgraph/Graph/edge.h	/^    EDGE_LISTS_NUM$/;"	e	enum:EdgeListType
+EDGE_LIST_GRAPH	showgraph/Graph/edge.h	/^    EDGE_LIST_GRAPH,$/;"	e	enum:EdgeListType
+EDGE_LIST_PREDS	showgraph/Graph/edge.h	/^    EDGE_LIST_PREDS,$/;"	e	enum:EdgeListType
+EDGE_LIST_SUCCS	showgraph/Graph/edge.h	/^    EDGE_LIST_SUCCS,$/;"	e	enum:EdgeListType
+EDGE_TYPES_NUM	showgraph/Layout/aux_edge.h	/^	EDGE_TYPES_NUM$/;"	e	enum:AuxEdgeType
+EDGE_W_H	showgraph/GraphView/edge_item.h	/^#define EDGE_W_H$/;"	d
+EXT_EDITOR_DEFAULT_PATH	gui/fileviewer.cpp	/^#define EXT_EDITOR_DEFAULT_PATH /;"	d	file:
+Edge	showgraph/Graph/edge.h	/^    Edge( Graph *_graph_p, GraphUid _id, Node *_pred, Node* _succ):$/;"	f	class:Edge
+Edge	showgraph/Graph/edge.h	/^class Edge: $/;"	c
+EdgeControlSize	showgraph/GraphView/edge_item.h	/^const qreal EdgeControlSize  = 5;$/;"	v
+EdgeHelper	showgraph/GraphView/edge_helper.cpp	/^EdgeHelper::EdgeHelper(): $/;"	f	class:EdgeHelper
+EdgeHelper	showgraph/GraphView/edge_helper.h	/^class EdgeHelper: public QGraphicsItem$/;"	c
+EdgeHelperState	showgraph/GraphView/edge_helper.h	/^enum EdgeHelperState$/;"	g
+EdgeItem	showgraph/GraphView/edge_item.cpp	/^EdgeItem::EdgeItem( GEdge *e_p): edge_p( e_p)$/;"	f	class:EdgeItem
+EdgeItem	showgraph/GraphView/edge_item.h	/^class EdgeItem: public QGraphicsItem$/;"	c
+EdgeIter	showgraph/Graph/node.h	/^    typedef EdgeIterIface< UnDirIterImpl> EdgeIter; \/**< Undirected iterator for edges *\/$/;"	t	class:Node
+EdgeIterIface	showgraph/Graph/node_inline.h	/^inline EdgeIterIface< EdgeIterImpl>::EdgeIterIface( Node *n):$/;"	f	class:EdgeIterIface
+EdgeIterIface	showgraph/Graph/node_inline.h	/^inline EdgeIterIface< EdgeIterImpl>::EdgeIterIface( const EdgeIterIface& proto)$/;"	f	class:EdgeIterIface
+EdgeIterIface	showgraph/Graph/node_inline.h	/^inline EdgeIterIface< EdgeIterImpl>::EdgeIterIface()$/;"	f	class:EdgeIterIface
+EdgeIterIface	showgraph/Graph/node_iter.h	/^template < class EdgeIterImpl> class EdgeIterIface$/;"	c
+EdgeListType	showgraph/Graph/edge.h	/^enum EdgeListType$/;"	g
+EdgeMode	showgraph/GraphView/edge_item.h	/^    typedef enum EdgeMode$/;"	g	class:EdgeItem
+EdgeMode	showgraph/GraphView/edge_item.h	/^    } EdgeMode;$/;"	t	class:EdgeItem	typeref:enum:EdgeItem::EdgeMode
+Entry	showgraph/Utils/mem_entry.h	/^    Entry< Data>::Entry()$/;"	f	class:MemImpl::Entry
+Entry	showgraph/Utils/mem_entry.h	/^    template < class Data> class Entry: private Data$/;"	c	namespace:MemImpl
+EntryNum	showgraph/Utils/mem_pool.h	/^    typedef quint32 EntryNum;$/;"	t	namespace:Mem
+EntrySize	showgraph/Utils/mem_pool.h	/^    typedef quint32 EntrySize;$/;"	t	namespace:Mem
+ExitTriggered	gui/mainwindow.cpp	/^void mainwindow::ExitTriggered(bool checked)$/;"	f	class:mainwindow
+FILEVIEWER_H_CQ	gui/fileviewer.h	/^#define FILEVIEWER_H_CQ$/;"	d
+FILEVIEWSETTINGSDIALOG_H_CQ	gui/fileviewsettingsdialog.h	/^#define FILEVIEWSETTINGSDIALOG_H_CQ$/;"	d
+FORWARD_EDGE	showgraph/Layout/aux_edge.h	/^	FORWARD_EDGE,$/;"	e	enum:AuxEdgeType
+FixedPool	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::FixedPool(): $/;"	f	class:Mem::FixedPool
+FixedPool	showgraph/Utils/mem_fixed_pool.h	/^    class FixedPool: public Pool$/;"	c	namespace:Mem
+ForEdges	showgraph/Graph/graph_iface.h	/^#  define ForEdges(/;"	d
+FreeOptList	makedb/optlist.cpp	/^void FreeOptList(option_t *list)$/;"	f
+GEdge	showgraph/GraphView/edge_item.cpp	/^GEdge::GEdge( GGraph *graph_p, int _id, GNode *_pred, GNode* _succ):$/;"	f	class:GEdge
+GEdge	showgraph/GraphView/edge_item.h	/^class GEdge: public AuxEdge$/;"	c
+GGraph	showgraph/GraphView/graph_view.h	/^    inline GGraph( GraphView *v, bool create_pools):$/;"	f	class:GGraph
+GGraph	showgraph/GraphView/graph_view.h	/^class GGraph: public AuxGraph$/;"	c
+GGraphError	showgraph/GraphView/gview_iface.h	/^    GGraphError( QString str): msg_priv( str){};$/;"	f	class:GGraphError
+GGraphError	showgraph/GraphView/gview_iface.h	/^    GGraphError(){};$/;"	f	class:GGraphError
+GGraphError	showgraph/GraphView/gview_iface.h	/^class GGraphError$/;"	c
+GNode	showgraph/GraphView/node_item.cpp	/^GNode::GNode( GGraph *graph_p, int _id):$/;"	f	class:GNode
+GNode	showgraph/GraphView/node_item.cpp	/^GNode::GNode( GGraph *graph_p, int _id, QPointF _pos):$/;"	f	class:GNode
+GNode	showgraph/GraphView/node_item.h	/^class GNode: public AuxNode$/;"	c
+GRAPHDIALOG_H_CQ	gui/graphdialog.h	/^#define GRAPHDIALOG_H_CQ$/;"	d
+GRAPH_ASSERTD	showgraph/Graph/predecls.h	/^#    define GRAPH_ASSERTD(/;"	d
+GRAPH_DIRS_NUM	showgraph/Graph/predecls.h	/^    GRAPH_DIRS_NUM = 2$/;"	e	enum:GraphDir
+GRAPH_DIR_DOWN	showgraph/Graph/predecls.h	/^    GRAPH_DIR_DOWN = 1,$/;"	e	enum:GraphDir
+GRAPH_DIR_UP	showgraph/Graph/predecls.h	/^	GRAPH_DIR_UP = 0,$/;"	e	enum:GraphDir
+GRAPH_H	showgraph/Graph/graph.h	/^#define GRAPH_H$/;"	d
+GRAPH_IFACE_H	showgraph/Graph/graph_iface.h	/^#define GRAPH_IFACE_H$/;"	d
+GRAPH_INLINE_H	showgraph/Graph/graph_inline.h	/^#define GRAPH_INLINE_H$/;"	d
+GRAPH_MARKER_CLEAN	showgraph/Graph/marker.h	/^const MarkerValue GRAPH_MARKER_CLEAN = 0;$/;"	v
+GRAPH_MARKER_FIRST	showgraph/Graph/marker.h	/^const MarkerValue GRAPH_MARKER_FIRST = 1;$/;"	v
+GRAPH_MARKER_LAST	showgraph/Graph/marker.h	/^const MarkerValue GRAPH_MARKER_LAST = ( MarkerValue)( (int)-1);$/;"	v
+GRAPH_MAX_EDGE_NUM	showgraph/Graph/predecls.h	/^const GraphNum GRAPH_MAX_EDGE_NUM = ( GraphNum)( -1);$/;"	v
+GRAPH_MAX_NODE_NUM	showgraph/Graph/predecls.h	/^const GraphNum GRAPH_MAX_NODE_NUM = ( GraphNum)( -1);$/;"	v
+GRAPH_PREDECLS_H	showgraph/Graph/predecls.h	/^#define GRAPH_PREDECLS_H$/;"	d
+GRAPH_VIEW_H	showgraph/GraphView/graph_view.h	/^#define GRAPH_VIEW_H$/;"	d
+GRAPH_VIEW_MODES_NUM	showgraph/GraphView/graph_view.h	/^    GRAPH_VIEW_MODES_NUM$/;"	e	enum:GraphViewMode
+GSTYLE_H	showgraph/GraphView/gstyle.h	/^#define GSTYLE_H$/;"	d
+GStyle	showgraph/GraphView/gstyle.h	/^GStyle::GStyle( QDomElement e ): $/;"	f	class:GStyle
+GStyle	showgraph/GraphView/gstyle.h	/^GStyle::GStyle( QString nm, const GStyle& st)$/;"	f	class:GStyle
+GStyle	showgraph/GraphView/gstyle.h	/^class GStyle$/;"	c
+GStyle	showgraph/GraphView/gstyle.h	/^inline GStyle::GStyle( const GStyle& st)$/;"	f	class:GStyle
+GStyle	showgraph/GraphView/gstyle.h	/^inline GStyle::GStyle(): $/;"	f	class:GStyle
+GVIEW_ASSERTD	showgraph/GraphView/gview_iface.h	/^#    define GVIEW_ASSERTD(/;"	d
+GVIEW_IFACE_H	showgraph/GraphView/gview_iface.h	/^#define GVIEW_IFACE_H$/;"	d
+GVIEW_IMPL_H	showgraph/GraphView/gview_impl.h	/^#define GVIEW_IMPL_H$/;"	d
+GetOptList	makedb/optlist.cpp	/^option_t *GetOptList(int argc, char* argv[], char* options)$/;"	f
+GetPeerInDir	showgraph/Utils/list.h	/^    inline ListItem<Data> * GetPeerInDir( ListDir dir) const$/;"	f	class:ListItem
+GetTmpSrc	showgraph/GraphView/graph_view.h	/^    inline GNode* GetTmpSrc()$/;"	f	class:GraphView
+GoToLine_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::GoToLine_ButtonClick(bool checked)$/;"	f	class:fileviewer
+Graph	showgraph/Graph/graph.cpp	/^Graph::Graph( bool create_pools):$/;"	f	class:Graph
+Graph	showgraph/Graph/graph.h	/^class Graph: public MarkerManager, public NumManager, public QDomDocument$/;"	c
+GraphDir	showgraph/Graph/predecls.h	/^enum GraphDir$/;"	g
+GraphNum	showgraph/Graph/predecls.h	/^typedef quint32 GraphNum;$/;"	t
+GraphUid	showgraph/Graph/predecls.h	/^typedef quint64 GraphUid;$/;"	t
+GraphView	showgraph/GraphView/graph_view.cpp	/^GraphView::GraphView(): $/;"	f	class:GraphView
+GraphView	showgraph/GraphView/graph_view.h	/^class GraphView: public QGraphicsView$/;"	c
+GraphViewHistory	showgraph/GraphView/graph_view.h	/^    GraphViewHistory(): events()$/;"	f	class:GraphViewHistory
+GraphViewHistory	showgraph/GraphView/graph_view.h	/^class GraphViewHistory$/;"	c
+GraphViewMode	showgraph/GraphView/graph_view.h	/^enum GraphViewMode$/;"	g
+Graph_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::Graph_ButtonClick(bool checked)$/;"	f	class:searchhandler
+HELPER_STATE_INITIAL	showgraph/GraphView/edge_helper.h	/^    HELPER_STATE_INITIAL,$/;"	e	enum:EdgeHelperState
+HELPER_STATE_REGULAR	showgraph/GraphView/edge_helper.h	/^    HELPER_STATE_REGULAR$/;"	e	enum:EdgeHelperState
+HIGHLIGHTER_H	gui/obsolete/highlighter.h	/^ #define HIGHLIGHTER_H$/;"	d
+Highlighter	gui/obsolete/highlighter.cpp	/^ Highlighter::Highlighter(QTextDocument *parent)$/;"	f	class:Highlighter
+Highlighter	gui/obsolete/highlighter.h	/^ class Highlighter : public QSyntaxHighlighter$/;"	c
+HighlightingRule	gui/obsolete/highlighter.h	/^     struct HighlightingRule$/;"	s	class:Highlighter
+IMAGE_EXPORT_SCALE_FACTOR	showgraph/showgraph.cpp	/^const int IMAGE_EXPORT_SCALE_FACTOR = 2;$/;"	v
+IMAGE_RECT_ADJUST	showgraph/showgraph.cpp	/^const qreal IMAGE_RECT_ADJUST = 10;$/;"	v
+ITERATE_GRAPH_EDGES	showgraph/Graph/graph_iface.h	/^#define ITERATE_GRAPH_EDGES(/;"	d
+ITERATE_GRAPH_NODES	showgraph/Graph/graph_iface.h	/^#define ITERATE_GRAPH_NODES(/;"	d
+ITERATE_NODE_EDGES	showgraph/Graph/graph_iface.h	/^#define ITERATE_NODE_EDGES(/;"	d
+ITERATE_NODE_PREDS	showgraph/Graph/graph_iface.h	/^#define ITERATE_NODE_PREDS(/;"	d
+ITERATE_NODE_SUCCS	showgraph/Graph/graph_iface.h	/^#define ITERATE_NODE_SUCCS(/;"	d
+IndentSize	showgraph/Graph/predecls.h	/^const int IndentSize = 4;$/;"	v
+IterImplBase	showgraph/Graph/node_iter.h	/^    inline IterImplBase(): edge_p( NULL) {}$/;"	f	class:IterImplBase
+IterImplBase	showgraph/Graph/node_iter.h	/^class IterImplBase$/;"	c
+LANGTABLE_H_CQ	gui/langtable.h	/^#define LANGTABLE_H_CQ$/;"	d
+LAYOUT_ASSERTD	showgraph/Layout/layout_iface.h	/^#    define LAYOUT_ASSERTD(/;"	d
+LAYOUT_IFACE_H	showgraph/Layout/layout_iface.h	/^#define LAYOUT_IFACE_H$/;"	d
+LEFT_SECTOR	showgraph/GraphView/navigation.h	/^    LEFT_SECTOR,$/;"	e	enum:NavSector
+LISTHANDLER_H_CQ	gui/listhandler.h	/^#define LISTHANDLER_H_CQ$/;"	d
+LISTS_NUM	showgraph/Utils/list_utest.cpp	/^    LISTS_NUM$/;"	e	enum:ListTypes	file:
+LIST_DIR_DEFAULT	showgraph/Utils/list.h	/^    LIST_DIR_DEFAULT = LIST_DIR_RIGHT,$/;"	e	enum:ListDir
+LIST_DIR_LEFT	showgraph/Utils/list.h	/^    LIST_DIR_LEFT = 1,$/;"	e	enum:ListDir
+LIST_DIR_NUM	showgraph/Utils/list.h	/^    LIST_DIR_NUM = 2$/;"	e	enum:ListDir
+LIST_DIR_RDEFAULT	showgraph/Utils/list.h	/^    LIST_DIR_RDEFAULT = LIST_DIR_LEFT,$/;"	e	enum:ListDir
+LIST_DIR_RIGHT	showgraph/Utils/list.h	/^    LIST_DIR_RIGHT = 0,$/;"	e	enum:ListDir
+LIST_H	showgraph/Utils/list.h	/^#define LIST_H$/;"	d
+LIST_ONE	showgraph/Utils/list_utest.cpp	/^    LIST_ONE,$/;"	e	enum:ListTypes	file:
+LIST_TWO	showgraph/Utils/list_utest.cpp	/^    LIST_TWO,$/;"	e	enum:ListTypes	file:
+LanguageTriggered	gui/mainwindow.cpp	/^void mainwindow::LanguageTriggered(bool checked)$/;"	f	class:mainwindow
+Level	showgraph/Layout/aux_graph.h	/^    inline Level( Rank r): level_rank( r), node_list(), _height( 0), y_pos( 0){};$/;"	f	class:Level
+Level	showgraph/Layout/aux_graph.h	/^    inline Level(): level_rank( 0), node_list(), _height( 0), y_pos( 0){};$/;"	f	class:Level
+Level	showgraph/Layout/aux_graph.h	/^class Level$/;"	c
+LineNumberArea	gui/obsolete/CodeEditor.h	/^     LineNumberArea(CodeEditor *editor) : QWidget(editor) {$/;"	f	class:LineNumberArea
+LineNumberArea	gui/obsolete/CodeEditor.h	/^ class LineNumberArea : public QWidget$/;"	c
+ListDir	showgraph/Utils/list.h	/^enum ListDir$/;"	g
+ListId	showgraph/Utils/list.h	/^typedef quint16 ListId;$/;"	t
+ListItem	showgraph/Utils/list.h	/^    ListItem( Data* d)$/;"	f	class:ListItem
+ListItem	showgraph/Utils/list.h	/^    ListItem( ListItem<Data> *peer, Data* d)$/;"	f	class:ListItem
+ListItem	showgraph/Utils/list.h	/^    ListItem( ListItem<Data> *peer, ListDir dir, Data *d)$/;"	f	class:ListItem
+ListItem	showgraph/Utils/list.h	/^    ListItem()$/;"	f	class:ListItem
+ListItem	showgraph/Utils/list.h	/^template <class Data> class ListItem$/;"	c
+ListRDir	showgraph/Utils/list.h	/^ListRDir( ListDir dir)$/;"	f
+ListTypes	showgraph/Utils/list_utest.cpp	/^enum ListTypes$/;"	g	file:
+MAINWINDOW_H_CQ	gui/mainwindow.h	/^#define MAINWINDOW_H_CQ$/;"	d
+MAX_CHUNK_ENTRIES_NUM	showgraph/Utils/mem.h	/^    const quint8 MAX_CHUNK_ENTRIES_NUM = ( quint8)( -1);$/;"	m	namespace:MemImpl
+MAX_CHUNK_ENTRIES_NUM	showgraph/Utils/mem.h	/^    const quint8 MAX_CHUNK_ENTRIES_NUM = 2;$/;"	m	namespace:MemImpl
+MAX_COT_VERTICAL	showgraph/GraphView/visible_edge.cpp	/^const qreal MAX_COT_VERTICAL = 0.1;$/;"	v
+MAX_DELETED_ITEMS_COUNT	showgraph/GraphView/graph_view.h	/^    static const int MAX_DELETED_ITEMS_COUNT = 10000;$/;"	m	class:GraphView
+MAX_DELETED_ITEMS_COUNT	showgraph/GraphView/graph_view.h	/^    static const int MAX_DELETED_ITEMS_COUNT = 100;$/;"	m	class:GraphView
+MAX_GRAPH_MARKERS	showgraph/Graph/marker.h	/^const short int MAX_GRAPH_MARKERS = 10;$/;"	v
+MAX_NUMERATIONS	showgraph/Graph/num.h	/^const short int MAX_NUMERATIONS = 10;$/;"	v
+MAX_OPACITY	showgraph/GraphView/gview_iface.h	/^const qreal MAX_OPACITY = 6;$/;"	v
+MAX_PLACE_LEN	showgraph/GraphView/gview_impl.h	/^const int MAX_PLACE_LEN = 3;$/;"	v
+MAX_PRIORITY	showgraph/GraphView/gview_impl.h	/^const int MAX_PRIORITY = 6;$/;"	v
+MAX_TAN_HORIZONTAL	showgraph/GraphView/visible_edge.cpp	/^const qreal MAX_TAN_HORIZONTAL = 0.1;$/;"	v
+MAX_VISIBLE_LEN	showgraph/GraphView/gview_impl.h	/^const int MAX_VISIBLE_LEN = 3;$/;"	v
+MEM_ASSERTD	showgraph/Utils/mem.h	/^#    define MEM_ASSERTD(/;"	d
+MEM_CHUNK_H	showgraph/Utils/mem_chunk.h	/^#define MEM_CHUNK_H$/;"	d
+MEM_ENTRY_H	showgraph/Utils/mem_entry.h	/^#define MEM_ENTRY_H$/;"	d
+MEM_FIXED_POOL_H	showgraph/Utils/mem_fixed_pool.h	/^#define MEM_FIXED_POOL_H$/;"	d
+MEM_H	showgraph/Utils/mem.h	/^#define MEM_H$/;"	d
+MEM_MGR_H	showgraph/Utils/mem_mgr.h	/^#define MEM_MGR_H$/;"	d
+MEM_OBJ_H	showgraph/Utils/mem_obj.h	/^#define MEM_OBJ_H$/;"	d
+MEM_POOL_H	showgraph/Utils/mem_pool.h	/^#define MEM_POOL_H$/;"	d
+MEM_REF_H	showgraph/Utils/mem_ref.h	/^#define MEM_REF_H$/;"	d
+MISC_H	showgraph/Utils/misc.h	/^#define MISC_H$/;"	d
+MListIface	showgraph/Utils/list.h	/^    inline MListIface( Item *peer):$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^    inline MListIface( Item *peer, ListDir dir):$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^    inline MListIface( ListId list, Item *peer):$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^    inline MListIface( ListId list, Item *peer, ListDir dir):$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^    inline MListIface(): ListBase(){};$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^    inline MListIface():$/;"	f	class:MListIface
+MListIface	showgraph/Utils/list.h	/^template < class Item, class ListBase, unsigned int dim> class MListIface: public ListBase$/;"	c
+MListIface	showgraph/Utils/list.h	/^template< class Item, class ListBase> class MListIface< Item, ListBase, 1>: public ListBase$/;"	c
+MListItem	showgraph/Utils/list.h	/^    MListItem( ListId list, MListItem< dim> *peer)$/;"	f	class:MListItem
+MListItem	showgraph/Utils/list.h	/^    MListItem( ListId list, MListItem< dim> *peer, ListDir dir)$/;"	f	class:MListItem
+MListItem	showgraph/Utils/list.h	/^    MListItem( MListItem< 1> *peer)$/;"	f	class:MListItem
+MListItem	showgraph/Utils/list.h	/^    MListItem( MListItem< 1> *peer, ListDir dir)$/;"	f	class:MListItem
+MListItem	showgraph/Utils/list.h	/^    MListItem()$/;"	f	class:MListItem
+MListItem	showgraph/Utils/list.h	/^template <unsigned int dim> class MListItem$/;"	c
+MListItem	showgraph/Utils/list.h	/^template<> class MListItem<1>$/;"	c
+M_ERROR_GENERIC	showgraph/Graph/marker.h	/^    M_ERROR_GENERIC,$/;"	e	enum:MarkerErrorType_e
+M_ERROR_NUM	showgraph/Graph/marker.h	/^    M_ERROR_NUM$/;"	e	enum:MarkerErrorType_e
+M_ERROR_OUT_OF_INDEXES	showgraph/Graph/marker.h	/^    M_ERROR_OUT_OF_INDEXES,$/;"	e	enum:MarkerErrorType_e
+M_ERROR_OUT_OF_VALUES	showgraph/Graph/marker.h	/^    M_ERROR_OUT_OF_VALUES,$/;"	e	enum:MarkerErrorType_e
+MakeOpt	makedb/optlist.cpp	/^option_t *MakeOpt(const char option, char *const argument, const int index)$/;"	f
+Marked	showgraph/Graph/marker.h	/^class Marked$/;"	c
+Marked	showgraph/Graph/marker.h	/^inline Marked::Marked()$/;"	f	class:Marked
+Marker	showgraph/Graph/marker.h	/^class Marker$/;"	c
+Marker	showgraph/Graph/marker.h	/^inline Marker::Marker(): $/;"	f	class:Marker
+MarkerErrorType	showgraph/Graph/marker.h	/^} MarkerErrorType;$/;"	t	typeref:enum:MarkerErrorType_e
+MarkerErrorType_e	showgraph/Graph/marker.h	/^typedef enum MarkerErrorType_e$/;"	g
+MarkerIndex	showgraph/Graph/marker.h	/^typedef unsigned short int MarkerIndex;$/;"	t
+MarkerManager	showgraph/Graph/marker.h	/^class MarkerManager$/;"	c
+MarkerManager	showgraph/Graph/marker.h	/^inline MarkerManager::MarkerManager()$/;"	f	class:MarkerManager
+MarkerValue	showgraph/Graph/marker.h	/^typedef unsigned int MarkerValue;$/;"	t
+MatchOpt	makedb/optlist.cpp	/^int MatchOpt(const char argument, char *const options)$/;"	f
+Mem	showgraph/Utils/mem.h	/^namespace Mem$/;"	n
+Mem	showgraph/Utils/mem_fixed_pool.h	/^namespace Mem$/;"	n
+Mem	showgraph/Utils/mem_obj.h	/^namespace Mem$/;"	n
+Mem	showgraph/Utils/mem_pool.h	/^namespace Mem$/;"	n
+Mem	showgraph/Utils/mem_ref.h	/^namespace Mem$/;"	n
+MemEventId	showgraph/Utils/mem_mgr.h	/^    typedef quint64 MemEventId;$/;"	t	namespace:MemImpl
+MemImpl	showgraph/Utils/mem.h	/^namespace MemImpl$/;"	n
+MemImpl	showgraph/Utils/mem_chunk.h	/^namespace MemImpl$/;"	n
+MemImpl	showgraph/Utils/mem_entry.h	/^namespace MemImpl$/;"	n
+MemImpl	showgraph/Utils/mem_mgr.h	/^namespace MemImpl$/;"	n
+MemInfo	showgraph/Utils/mem_mgr.cpp	/^MemInfo::MemInfo()$/;"	f	class:MemInfo
+MemInfo	showgraph/Utils/mem_mgr.h	/^        MemInfo( const MemInfo&){};$/;"	f	class:MemImpl::MemInfo
+MemInfo	showgraph/Utils/mem_mgr.h	/^    class MemInfo$/;"	c	namespace:MemImpl
+MemMgr	showgraph/Utils/mem.h	/^    typedef Single< MemImpl::MemInfo> MemMgr;$/;"	t	namespace:Mem
+ModeEdit	showgraph/GraphView/edge_item.h	/^        ModeEdit$/;"	e	enum:EdgeItem::EdgeMode
+ModeShow	showgraph/GraphView/edge_item.h	/^        ModeShow,$/;"	e	enum:EdgeItem::EdgeMode
+MyPoolObj	showgraph/Utils/mem_utest.cpp	/^class MyPoolObj: public PoolBase, public SListIface< MyPoolObj, SListItem>$/;"	c	file:
+NAVIGATION_H	showgraph/GraphView/navigation.h	/^#define NAVIGATION_H$/;"	d
+NAV_DIR_DOWN	showgraph/GraphView/navigation.h	/^    NAV_DIR_DOWN,$/;"	e	enum:NavDirection
+NAV_DIR_LEFT	showgraph/GraphView/navigation.h	/^    NAV_DIR_LEFT,$/;"	e	enum:NavDirection
+NAV_DIR_RIGHT	showgraph/GraphView/navigation.h	/^    NAV_DIR_RIGHT$/;"	e	enum:NavDirection
+NAV_DIR_UP	showgraph/GraphView/navigation.h	/^    NAV_DIR_UP,$/;"	e	enum:NavDirection
+NAV_EVENT_NODE_FOCUS	showgraph/GraphView/graph_view.h	/^    NAV_EVENT_NODE_FOCUS,$/;"	e	enum:NavEventType
+NAV_EVENT_TYPES_NUM	showgraph/GraphView/graph_view.h	/^    NAV_EVENT_TYPES_NUM$/;"	e	enum:NavEventType
+NODE_CONTROL_MARGIN	showgraph/Layout/layout_iface.h	/^const qreal NODE_CONTROL_MARGIN = 5;$/;"	v
+NODE_GROUP_H	showgraph/Layout/node_group.h	/^#define NODE_GROUP_H$/;"	d
+NODE_H	showgraph/Graph/node.h	/^#define NODE_H$/;"	d
+NODE_INLINE_H	showgraph/Graph/node_inline.h	/^#define NODE_INLINE_H$/;"	d
+NODE_ITER_H	showgraph/Graph/node_iter.h	/^#define NODE_ITER_H$/;"	d
+NODE_NODE_MARGIN	showgraph/Layout/layout_iface.h	/^const qreal NODE_NODE_MARGIN = 30;$/;"	v
+NODE_SHAPES_NUM	showgraph/GraphView/gstyle.h	/^    NODE_SHAPES_NUM    $/;"	e	enum:NodeShape
+NODE_SHAPE_BOX	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_BOX,$/;"	e	enum:NodeShape
+NODE_SHAPE_CIRCLE	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_CIRCLE,$/;"	e	enum:NodeShape
+NODE_SHAPE_DEFAULT	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_DEFAULT = NODE_SHAPE_BOX,$/;"	e	enum:NodeShape
+NODE_SHAPE_DIAMOND	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_DIAMOND,$/;"	e	enum:NodeShape
+NODE_SHAPE_ELLIPSE	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_ELLIPSE,$/;"	e	enum:NodeShape
+NODE_SHAPE_ROUNDED_BOX	showgraph/GraphView/gstyle.h	/^    NODE_SHAPE_ROUNDED_BOX,$/;"	e	enum:NodeShape
+NODE_SPEED	showgraph/GraphView/gview_impl.h	/^const qreal NODE_SPEED = 4;$/;"	v
+NODE_W_H	showgraph/GraphView/node_item.h	/^#define NODE_W_H$/;"	d
+NUMBER_MAX	showgraph/Graph/num.h	/^const GraphNum NUMBER_MAX = (( GraphNum) -1) - 1;$/;"	v
+NUMBER_NO_NUM	showgraph/Graph/num.h	/^const GraphNum NUMBER_NO_NUM = ( GraphNum) -1;$/;"	v
+NUM_ERROR_GENERIC	showgraph/Graph/num.h	/^    NUM_ERROR_GENERIC,$/;"	e	enum:NumErrorType
+NUM_ERROR_NUM	showgraph/Graph/num.h	/^    NUM_ERROR_NUM$/;"	e	enum:NumErrorType
+NUM_ERROR_NUMBER_OUT_OF_RANGE	showgraph/Graph/num.h	/^    NUM_ERROR_NUMBER_OUT_OF_RANGE,$/;"	e	enum:NumErrorType
+NUM_ERROR_OUT_OF_INDEXES	showgraph/Graph/num.h	/^    NUM_ERROR_OUT_OF_INDEXES,$/;"	e	enum:NumErrorType
+NUM_ERROR_OUT_OF_VALUES	showgraph/Graph/num.h	/^    NUM_ERROR_OUT_OF_VALUES,$/;"	e	enum:NumErrorType
+NUM_OF_THEMES	gui/themes_gen.cpp	/^#define NUM_OF_THEMES /;"	d	file:
+NUM_VAL_CLEAN	showgraph/Graph/num.h	/^const NumValue NUM_VAL_CLEAN = 0;$/;"	v
+NUM_VAL_FIRST	showgraph/Graph/num.h	/^const NumValue NUM_VAL_FIRST = 1;$/;"	v
+NUM_VAL_LAST	showgraph/Graph/num.h	/^const NumValue NUM_VAL_LAST = ( NumValue)( (int)-1);$/;"	v
+NavDirection	showgraph/GraphView/navigation.h	/^enum NavDirection$/;"	g
+NavEvent	showgraph/GraphView/graph_view.h	/^    inline NavEvent( NavEventType t): type( t)$/;"	f	class:NavEvent
+NavEvent	showgraph/GraphView/graph_view.h	/^    inline NavEvent( NavEventType t, GNode *n): type( t)$/;"	f	class:NavEvent
+NavEvent	showgraph/GraphView/graph_view.h	/^class NavEvent$/;"	c
+NavEventData	showgraph/GraphView/graph_view.h	/^    union NavEventData$/;"	u	class:NavEvent
+NavEventType	showgraph/GraphView/graph_view.h	/^enum NavEventType$/;"	g
+NavSector	showgraph/GraphView/navigation.h	/^enum NavSector$/;"	g
+NextSearch_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::NextSearch_ButtonClick(bool checked)$/;"	f	class:searchhandler
+Next_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::Next_ButtonClick(bool checked)$/;"	f	class:fileviewer
+Node	showgraph/Graph/node.h	/^class Node: public Marked, public Numbered, public PoolObj, public SListIface< Node>$/;"	c
+Node	showgraph/Graph/node_inline.h	/^inline Node::Node( Graph *_graph_p, GraphUid _id):uid(_id), graph_p( _graph_p), element()$/;"	f	class:Node
+NodeGroup	showgraph/Layout/node_group.cpp	/^NodeGroup::NodeGroup( AuxNode *n,   \/\/ Parent node$/;"	f	class:NodeGroup
+NodeGroup	showgraph/Layout/node_group.h	/^    NodeGroup() : node_list()$/;"	f	class:NodeGroup
+NodeGroup	showgraph/Layout/node_group.h	/^class NodeGroup$/;"	c
+NodeItem	showgraph/GraphView/node_item.h	/^	inline NodeItem( GNode *n_p):$/;"	f	class:NodeItem
+NodeItem	showgraph/GraphView/node_item.h	/^class NodeItem: public QGraphicsTextItem$/;"	c
+NodeNav	showgraph/GraphView/navigation.cpp	/^NodeNav::NodeNav( GNode *curr_node, NavSector nav_sector):$/;"	f	class:NodeNav
+NodeNav	showgraph/GraphView/navigation.h	/^class NodeNav$/;"	c
+NodeShape	showgraph/GraphView/gstyle.h	/^enum NodeShape$/;"	g
+NumErrorType	showgraph/Graph/num.h	/^enum NumErrorType$/;"	g
+NumIndex	showgraph/Graph/num.h	/^typedef unsigned short int NumIndex;$/;"	t
+NumManager	showgraph/Graph/num.h	/^class NumManager$/;"	c
+NumManager	showgraph/Graph/num.h	/^inline NumManager::NumManager()$/;"	f	class:NumManager
+NumValue	showgraph/Graph/num.h	/^typedef unsigned int NumValue;$/;"	t
+Numbered	showgraph/Graph/num.h	/^class Numbered$/;"	c
+Numbered	showgraph/Graph/num.h	/^inline Numbered::Numbered()$/;"	f	class:Numbered
+Numeration	showgraph/Graph/num.h	/^class Numeration$/;"	c
+Numeration	showgraph/Graph/num.h	/^inline Numeration::Numeration():$/;"	f	class:Numeration
+OL_NOINDEX	makedb/optlist.h	/^#define    OL_NOINDEX /;"	d
+OPACITY_STEP	showgraph/GraphView/gview_impl.h	/^const qreal OPACITY_STEP = 0.1;$/;"	v
+OPTLIST_H	makedb/optlist.h	/^#define OPTLIST_H$/;"	d
+OPT_BOOL	showgraph/Utils/conf.h	/^    OPT_BOOL,$/;"	e	enum:OptType
+OPT_FLOAT	showgraph/Utils/conf.h	/^    OPT_FLOAT,$/;"	e	enum:OptType
+OPT_INT	showgraph/Utils/conf.h	/^    OPT_INT,$/;"	e	enum:OptType
+OPT_STRING	showgraph/Utils/conf.h	/^    OPT_STRING,$/;"	e	enum:OptType
+OPT_TYPES_NUM	showgraph/Utils/conf.h	/^    OPT_TYPES_NUM$/;"	e	enum:OptType
+Obj	showgraph/Utils/mem_obj.h	/^		inline Obj() $/;"	f	class:Mem::Obj
+Obj	showgraph/Utils/mem_obj.h	/^    class Obj$/;"	c	namespace:Mem
+ObjRef	showgraph/Utils/mem_utest.cpp	/^typedef Ref< TestObj> ObjRef;$/;"	t	file:
+OpenDB_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::OpenDB_ButtonClick(bool checked)$/;"	f	class:searchhandler
+OpenDB_indexChanged	gui/searchhandler.cpp	/^void searchhandler::OpenDB_indexChanged(const int& idx)$/;"	f	class:searchhandler
+OpenInEditor_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::OpenInEditor_ButtonClick(bool checked)$/;"	f	class:fileviewer
+OptType	showgraph/Utils/conf.h	/^enum OptType$/;"	g
+OptValues	showgraph/Utils/conf.h	/^union OptValues$/;"	u
+Option	showgraph/Utils/conf.h	/^    Option( OptType _t, QString sname, QString lname, QString d):$/;"	f	class:Option
+Option	showgraph/Utils/conf.h	/^    Option( QString sname, QString lname, QString d):$/;"	f	class:Option
+Option	showgraph/Utils/conf.h	/^    Option( QString sname, QString lname, QString d, bool val):$/;"	f	class:Option
+Option	showgraph/Utils/conf.h	/^class Option$/;"	c
+OptionsExtEditor_Triggered	gui/fileviewer.cpp	/^void fileviewer::OptionsExtEditor_Triggered(bool checked)$/;"	f	class:fileviewer
+POOL_FIXED	showgraph/Utils/mem_pool.h	/^        POOL_FIXED,$/;"	e	enum:Mem::PoolType
+POOL_FLOAT	showgraph/Utils/mem_pool.h	/^        POOL_FLOAT,$/;"	e	enum:Mem::PoolType
+POOL_TYPES_NUM	showgraph/Utils/mem_pool.h	/^        POOL_TYPES_NUM$/;"	e	enum:Mem::PoolType
+PRINT_H	showgraph/Utils/print.h	/^#define PRINT_H$/;"	d
+Paste_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::Paste_ButtonClick(bool checked)$/;"	f	class:fileviewer
+Pi	showgraph/GraphView/gview_impl.h	/^static const double Pi = 3.14159265358979323846264338327950288419717;$/;"	v
+Pool	showgraph/Utils/mem_pool.h	/^    class Pool$/;"	c	namespace:Mem
+PoolBase	showgraph/Utils/mem_utest.cpp	/^class PoolBase: public PoolObj $/;"	c	file:
+PoolObj	showgraph/Utils/mem_pool.h	/^        PoolObj( PoolObj &obj){};$/;"	f	class:Mem::PoolObj
+PoolObj	showgraph/Utils/mem_pool.h	/^        PoolObj(): to_be_deleted( false){};$/;"	f	class:Mem::PoolObj
+PoolObj	showgraph/Utils/mem_pool.h	/^        inline PoolObj(){};$/;"	f	class:Mem::PoolObj
+PoolObj	showgraph/Utils/mem_pool.h	/^    class PoolObj$/;"	c	namespace:Mem
+PoolType	showgraph/Utils/mem_pool.h	/^    enum PoolType$/;"	g	namespace:Mem
+Pred	showgraph/Graph/node.h	/^    typedef EdgeIterIface< PredIterImpl> Pred;      \/**< Iterator for predecessors     *\/$/;"	t	class:Node
+PredIterImpl	showgraph/Graph/node_inline.h	/^inline PredIterImpl::PredIterImpl( Node *n)$/;"	f	class:PredIterImpl
+PredIterImpl	showgraph/Graph/node_iter.h	/^    inline PredIterImpl(){};      \/**< Default constructor *\/$/;"	f	class:PredIterImpl
+PredIterImpl	showgraph/Graph/node_iter.h	/^class PredIterImpl: public IterImplBase$/;"	c
+PrevSearch_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::PrevSearch_ButtonClick(bool checked)$/;"	f	class:searchhandler
+Prev_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::Prev_ButtonClick(bool checked)$/;"	f	class:fileviewer
+PrintUtils	showgraph/Utils/print.h	/^namespace PrintUtils$/;"	n
+Q_OBJECT	showgraph/GraphView/graph_view.h	/^    Q_OBJECT; \/** For MOC *\/$/;"	m	class:GraphView
+Q_OBJECT	showgraph/GraphView/style_edit.h	/^    Q_OBJECT;$/;"	m	class:StyleEdit
+Q_OBJECT	showgraph/Layout/aux_graph.h	/^    Q_OBJECT;$/;"	m	class:AuxGraph
+QueryType_indexChanged	gui/searchhandler.cpp	/^void searchhandler::QueryType_indexChanged(const int& idx)$/;"	f	class:searchhandler
+RANK_SPACING	showgraph/Layout/layout_iface.h	/^const qreal RANK_SPACING = 40;$/;"	v
+RANK_UNDEF	showgraph/Layout/layout_iface.h	/^const Rank RANK_UNDEF = (Rank) (-1);$/;"	v
+RIGHT_SECTOR	showgraph/GraphView/navigation.h	/^    RIGHT_SECTOR,$/;"	e	enum:NavSector
+Rank	showgraph/Layout/layout_iface.h	/^typedef unsigned int Rank;$/;"	t
+Ref	showgraph/Utils/mem_ref.h	/^		Ref( RefObj* p): ptr( p)$/;"	f	class:Mem::Ref
+Ref	showgraph/Utils/mem_ref.h	/^		Ref( const Ref< RefObj>& orig): ptr( orig.ptr)$/;"	f	class:Mem::Ref
+Ref	showgraph/Utils/mem_ref.h	/^		Ref(): ptr( NULL){};$/;"	f	class:Mem::Ref
+Ref	showgraph/Utils/mem_ref.h	/^    template < class RefObj> class Ref$/;"	c	namespace:Mem
+RefNumber	showgraph/Utils/mem_obj.h	/^	typedef unsigned int RefNumber;$/;"	t	namespace:Mem
+RevDir	showgraph/Graph/predecls.h	/^RevDir( GraphDir dir)$/;"	f
+SEARCHHANDLER_H_CQ	gui/searchhandler.h	/^#define SEARCHHANDLER_H_CQ$/;"	d
+SELF_EDGE	showgraph/Layout/aux_edge.h	/^	SELF_EDGE,$/;"	e	enum:AuxEdgeType
+SE_HOR_MARGIN	showgraph/GraphView/gview_impl.h	/^const qreal SE_HOR_MARGIN = 20;$/;"	v
+SE_VERT_MARGIN	showgraph/GraphView/gview_impl.h	/^const qreal SE_VERT_MARGIN = 20;$/;"	v
+SHOWGRAPH_H_CQ	showgraph/showgraph.h	/^#define SHOWGRAPH_H_CQ$/;"	d
+SIMPLE_DFS	showgraph/Layout/layout.cpp	/^#define SIMPLE_DFS$/;"	d	file:
+SINGLETON_H	showgraph/Utils/singleton.h	/^#define SINGLETON_H$/;"	d
+SListIface	showgraph/Utils/list.h	/^    inline SListIface( Item *peer):$/;"	f	class:SListIface
+SListIface	showgraph/Utils/list.h	/^    inline SListIface( Item *peer, ListDir dir):$/;"	f	class:SListIface
+SListIface	showgraph/Utils/list.h	/^    inline SListIface():$/;"	f	class:SListIface
+SListIface	showgraph/Utils/list.h	/^template< class Item, class ListBase=SListItem> class SListIface: public ListBase$/;"	c
+SListItem	showgraph/Utils/list.h	/^typedef MListItem< 1> SListItem;$/;"	t
+SMALL_LIB_H_CQ	querylib/small_lib.h	/^#define SMALL_LIB_H_CQ$/;"	d
+SQLBASE_H_CQ	makedb/sqlbase.h	/^#define SQLBASE_H_CQ$/;"	d
+SQLQUERYADV_H_CQ	gui/sqlqueryadv.h	/^#define SQLQUERYADV_H_CQ$/;"	d
+SQLQUERY_H_CQ	querylib/sqlquery.h	/^#define SQLQUERY_H_CQ$/;"	d
+SQL_AUTOCOMPLETE	querylib/sqlquery.cpp	/^#define SQL_AUTOCOMPLETE /;"	d	file:
+SQL_CALLEDFUNC	querylib/sqlquery.cpp	/^#define SQL_CALLEDFUNC /;"	d	file:
+SQL_CALLINGFUNC	querylib/sqlquery.cpp	/^#define SQL_CALLINGFUNC /;"	d	file:
+SQL_CALLS_OF_FUNC	querylib/sqlquery.cpp	/^#define SQL_CALLS_OF_FUNC /;"	d	file:
+SQL_CHILDCLASS	querylib/sqlquery.cpp	/^#define SQL_CHILDCLASS /;"	d	file:
+SQL_CLASS_STRUCT	querylib/sqlquery.cpp	/^#define SQL_CLASS_STRUCT /;"	d	file:
+SQL_EM_CALLEDFUNC	querylib/sqlquery.cpp	/^#define SQL_EM_CALLEDFUNC /;"	d	file:
+SQL_EM_CALLINGFUNC	querylib/sqlquery.cpp	/^#define SQL_EM_CALLINGFUNC /;"	d	file:
+SQL_EM_CALLS_OF_FUNC	querylib/sqlquery.cpp	/^#define SQL_EM_CALLS_OF_FUNC /;"	d	file:
+SQL_EM_CHILDCLASS	querylib/sqlquery.cpp	/^#define SQL_EM_CHILDCLASS /;"	d	file:
+SQL_EM_CLASS_STRUCT	querylib/sqlquery.cpp	/^#define SQL_EM_CLASS_STRUCT /;"	d	file:
+SQL_EM_FILEPATH	querylib/sqlquery.cpp	/^#define SQL_EM_FILEPATH /;"	d	file:
+SQL_EM_FUNC_MACRO	querylib/sqlquery.cpp	/^#define SQL_EM_FUNC_MACRO /;"	d	file:
+SQL_EM_INCLUDE	querylib/sqlquery.cpp	/^#define SQL_EM_INCLUDE /;"	d	file:
+SQL_EM_MEMBERS	querylib/sqlquery.cpp	/^#define SQL_EM_MEMBERS /;"	d	file:
+SQL_EM_OWNERCLASS	querylib/sqlquery.cpp	/^#define SQL_EM_OWNERCLASS /;"	d	file:
+SQL_EM_PARENTCLASS	querylib/sqlquery.cpp	/^#define SQL_EM_PARENTCLASS /;"	d	file:
+SQL_EM_SYM	querylib/sqlquery.cpp	/^#define SQL_EM_SYM /;"	d	file:
+SQL_FILEPATH	querylib/sqlquery.cpp	/^#define SQL_FILEPATH /;"	d	file:
+SQL_FUNCSINFILE	querylib/sqlquery.cpp	/^#define SQL_FUNCSINFILE /;"	d	file:
+SQL_FUNC_MACRO	querylib/sqlquery.cpp	/^#define SQL_FUNC_MACRO /;"	d	file:
+SQL_INCLUDE	querylib/sqlquery.cpp	/^#define SQL_INCLUDE /;"	d	file:
+SQL_MEMBERS	querylib/sqlquery.cpp	/^#define SQL_MEMBERS /;"	d	file:
+SQL_OWNERCLASS	querylib/sqlquery.cpp	/^#define SQL_OWNERCLASS /;"	d	file:
+SQL_PARENTCLASS	querylib/sqlquery.cpp	/^#define SQL_PARENTCLASS /;"	d	file:
+SQL_SYM	querylib/sqlquery.cpp	/^#define SQL_SYM /;"	d	file:
+STD2QT_H_CQ	gui/std2qt.h	/^#define STD2QT_H_CQ$/;"	d
+STYLE_EDIT_H	showgraph/GraphView/style_edit.h	/^#define STYLE_EDIT_H$/;"	d
+SWVER_H_CQ	makedb/swver.h	/^#define SWVER_H_CQ$/;"	d
+Search_ButtonClick	gui/searchhandler.cpp	/^void searchhandler::Search_ButtonClick(bool checked)$/;"	f	class:searchhandler
+Search_EnterKeyPressed	gui/searchhandler.cpp	/^void searchhandler::Search_EnterKeyPressed()$/;"	f	class:searchhandler
+SetCreateEdge	showgraph/GraphView/graph_view.h	/^    inline void SetCreateEdge( bool val)$/;"	f	class:GraphView
+SetInitFlags	showgraph/GraphView/node_item.cpp	/^NodeItem::SetInitFlags()$/;"	f	class:NodeItem
+SetNext	showgraph/Utils/list.h	/^    inline void SetNext( ListItem<Data> *n)$/;"	f	class:ListItem
+SetPeerInDir	showgraph/Utils/list.h	/^    inline void SetPeerInDir( ListItem<Data> *p, ListDir dir)$/;"	f	class:ListItem
+SetPrev	showgraph/Utils/list.h	/^    inline void SetPrev( ListItem<Data> *p)$/;"	f	class:ListItem
+SetTmpSrc	showgraph/GraphView/graph_view.h	/^    inline void SetTmpSrc( GNode* node)$/;"	f	class:GraphView
+SimpleDfsStepInfo	showgraph/Layout/aux_graph.h	/^        SimpleDfsStepInfo( AuxNode *n)$/;"	f	struct:AuxGraph::SimpleDfsStepInfo
+SimpleDfsStepInfo	showgraph/Layout/aux_graph.h	/^        SimpleDfsStepInfo( AuxNode *n, GraphDir dir)$/;"	f	struct:AuxGraph::SimpleDfsStepInfo
+SimpleDfsStepInfo	showgraph/Layout/aux_graph.h	/^    struct SimpleDfsStepInfo$/;"	s	class:AuxGraph
+Single	showgraph/Utils/singleton.h	/^template < class T> class Single$/;"	c
+SingleA	showgraph/Utils/utils_utest.cpp	/^typedef Single< classA> SingleA;$/;"	t	file:
+StyleEdit	showgraph/GraphView/style_edit.cpp	/^StyleEdit::StyleEdit( QWidget *parent, bool show_additional)$/;"	f	class:StyleEdit
+StyleEdit	showgraph/GraphView/style_edit.h	/^class StyleEdit: public QDialog$/;"	c
+StyleEditInfo	showgraph/GraphView/graph_view.h	/^        StyleEditInfo( GEdge* e, GStyle *olds, GStyle *news, StyleEdit* d):$/;"	f	struct:GraphView::StyleEditInfo
+StyleEditInfo	showgraph/GraphView/graph_view.h	/^        StyleEditInfo( GNode* n, GStyle *olds, GStyle *news, StyleEdit* d):$/;"	f	struct:GraphView::StyleEditInfo
+StyleEditInfo	showgraph/GraphView/graph_view.h	/^    struct StyleEditInfo$/;"	s	class:GraphView
+StyleId	showgraph/GraphView/gstyle.h	/^typedef quint32 StyleId;$/;"	t
+Succ	showgraph/Graph/node.h	/^    typedef EdgeIterIface< SuccIterImpl> Succ;      \/**< Iterator for successors       *\/$/;"	t	class:Node
+SuccIterImpl	showgraph/Graph/node_inline.h	/^inline SuccIterImpl::SuccIterImpl( Node *n)$/;"	f	class:SuccIterImpl
+SuccIterImpl	showgraph/Graph/node_iter.h	/^    inline SuccIterImpl(){};      \/**< Default constructor *\/$/;"	f	class:SuccIterImpl
+SuccIterImpl	showgraph/Graph/node_iter.h	/^class SuccIterImpl: public IterImplBase$/;"	c
+THEMES_H_CQ	gui/themes.h	/^#define THEMES_H_CQ$/;"	d
+TOP_SECTOR	showgraph/GraphView/navigation.h	/^    TOP_SECTOR,$/;"	e	enum:NavSector
+TREE_EDGE	showgraph/Layout/aux_edge.h	/^	TREE_EDGE,$/;"	e	enum:AuxEdgeType
+TestObj	showgraph/Utils/mem_utest.cpp	/^class TestObj: public Obj$/;"	c	file:
+TextEnlarge_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::TextEnlarge_ButtonClick(bool checked)$/;"	f	class:fileviewer
+TextShrink_ButtonClick	gui/fileviewer.cpp	/^void fileviewer::TextShrink_ButtonClick(bool checked)$/;"	f	class:fileviewer
+TwoPi	showgraph/GraphView/gview_impl.h	/^static double TwoPi = 2.0 * Pi;$/;"	v
+Type	showgraph/GraphView/edge_helper.h	/^    enum {Type = TypeEdgeHelper};$/;"	e	enum:EdgeHelper::__anon7
+Type	showgraph/GraphView/edge_item.h	/^    enum {Type = TypeEdge};$/;"	e	enum:EdgeItem::__anon8
+Type	showgraph/GraphView/node_item.h	/^    enum {Type = TypeNode};$/;"	e	enum:NodeItem::__anon10
+TypeEdge	showgraph/GraphView/gview_iface.h	/^    TypeEdge = QGraphicsItem::UserType + 2, \/** Edge item *\/$/;"	e	enum:__anon9
+TypeEdgeControl	showgraph/GraphView/gview_iface.h	/^    TypeEdgeControl = QGraphicsItem::UserType + 3,\/** EdgeControl item *\/$/;"	e	enum:__anon9
+TypeEdgeHelper	showgraph/GraphView/gview_iface.h	/^    TypeEdgeHelper = QGraphicsItem::UserType + 4 \/** Edge helper item *\/$/;"	e	enum:__anon9
+TypeNode	showgraph/GraphView/gview_iface.h	/^    TypeNode = QGraphicsItem::UserType + 1, \/** Node item *\/$/;"	e	enum:__anon9
+ULIST_H	showgraph/Utils/ulist.h	/^#define ULIST_H$/;"	d
+UNDEF_POS	showgraph/Utils/mem.h	/^    const ChunkPos UNDEF_POS = MAX_CHUNK_ENTRIES_NUM; $/;"	m	namespace:MemImpl
+UNDEF_SECTOR	showgraph/GraphView/navigation.h	/^    UNDEF_SECTOR$/;"	e	enum:NavSector
+UNKNOWN_TYPE_EDGE	showgraph/Layout/aux_edge.h	/^	UNKNOWN_TYPE_EDGE = 0,$/;"	e	enum:AuxEdgeType
+USE_MEM_EVENTS	showgraph/Utils/mem.h	/^#  define USE_MEM_EVENTS$/;"	d
+USE_MEM_EVENTS	showgraph/Utils/mem.h	/^#undef USE_MEM_EVENTS$/;"	d
+USE_REF_COUNTERS	showgraph/Utils/mem.h	/^#  define USE_REF_COUNTERS$/;"	d
+USE_REF_COUNTERS	showgraph/Utils/mem.h	/^#undef USE_REF_COUNTERS$/;"	d
+UTILS_IFACE_H	showgraph/Utils/utils_iface.h	/^#define UTILS_IFACE_H$/;"	d
+Ui	gui/aboutdialog.h	/^ namespace Ui {$/;"	n
+Ui	gui/fileviewsettingsdialog.h	/^ namespace Ui {$/;"	n
+Ui	gui/graphdialog.h	/^ namespace Ui {$/;"	n
+Ui	gui/mainwindow.h	/^ namespace Ui {$/;"	n
+UnDirIterImpl	showgraph/Graph/node_inline.h	/^inline UnDirIterImpl::UnDirIterImpl( Node *n)$/;"	f	class:UnDirIterImpl
+UnDirIterImpl	showgraph/Graph/node_iter.h	/^    inline UnDirIterImpl():is_pred( false){};      \/**< Default consturctor *\/$/;"	f	class:UnDirIterImpl
+UnDirIterImpl	showgraph/Graph/node_iter.h	/^class UnDirIterImpl: public IterImplBase$/;"	c
+Up_ButtonClick	gui/listhandler.cpp	/^void listhandler::Up_ButtonClick(bool checked)$/;"	f	class:listhandler
+UpdatePlacement	showgraph/GraphView/graph_view.cpp	/^void GGraph::UpdatePlacement()$/;"	f	class:GGraph
+Utils	showgraph/Utils/utils_iface.h	/^namespace Utils$/;"	n
+VEdge	showgraph/GraphView/visible_edge.cpp	/^VEdge::VEdge( GEdge *prototype)$/;"	f	class:VEdge
+VEdge	showgraph/GraphView/visible_edge.cpp	/^VEdge::VEdge( GNode *pred_node, GNode *succ_node):$/;"	f	class:VEdge
+VEdge	showgraph/GraphView/visible_edge.h	/^class VEdge$/;"	c
+VISIBLE_EDGE_H	showgraph/GraphView/visible_edge.h	/^#define VISIBLE_EDGE_H$/;"	d
+WHOLE_GRAPH_VIEW	showgraph/GraphView/graph_view.h	/^    WHOLE_GRAPH_VIEW,$/;"	e	enum:GraphViewMode
+WinMain	gui/winmain.cpp	/^int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)$/;"	f
+_doc	showgraph/GraphView/node_item.h	/^    QTextDocument* _doc;$/;"	m	class:GNode
+_height	showgraph/Layout/aux_graph.h	/^    qreal _height;$/;"	m	class:Level
+_pool	showgraph/Utils/mem_obj.h	/^        Pool *_pool;$/;"	m	class:Mem::Obj
+_style	showgraph/GraphView/edge_item.h	/^    GStyle *_style;$/;"	m	class:GEdge
+_style	showgraph/GraphView/node_item.h	/^    GStyle *_style;$/;"	m	class:GNode
+_type	showgraph/Utils/conf.h	/^    OptType _type;$/;"	m	class:Option
+a	showgraph/Utils/mem_utest.cpp	/^	int a;$/;"	m	class:TestObj	file:
+a	showgraph/Utils/mem_utest.cpp	/^    quint32 a;$/;"	m	class:MyPoolObj	file:
+abs	showgraph/Utils/misc.h	/^template<class Value> inline Value abs( Value val)$/;"	f
+add	showgraph/Layout/aux_graph.h	/^    inline void add( AuxNode *node)$/;"	f	class:Level
+addNode	showgraph/Layout/node_group.h	/^    inline void addNode( AuxNode *node)$/;"	f	class:NodeGroup
+addOption	showgraph/Utils/conf.h	/^    inline void addOption( OptType _t, QString sname, QString lname, QString d)$/;"	f	class:Conf
+addOption	showgraph/Utils/conf.h	/^    inline void addOption( Option *opt)$/;"	f	class:Conf
+addOption	showgraph/Utils/conf.h	/^    inline void addOption( QString sname, QString lname, QString d)$/;"	f	class:Conf
+addOption	showgraph/Utils/conf.h	/^    inline void addOption( QString sname, QString lname, QString d, bool val)$/;"	f	class:Conf
+addStyle	showgraph/GraphView/graph_view.h	/^    void addStyle( QString &name, GStyle *style)$/;"	f	class:GGraph
+addToSearchMemory	gui/searchhandler.cpp	/^void searchhandler::addToSearchMemory(const QString& searchtxt, const QString& filtertxt)$/;"	f	class:searchhandler
+add_escape_char	querylib/small_lib.cpp	/^std::string add_escape_char(const char* oristr, char chr2escp, char escpchr)$/;"	f
+add_escape_char	querylib/small_lib.cpp	/^std::string add_escape_char(std::string ori, char chr2escp, char escpchr)$/;"	f
+add_symbols	makedb/cs2sq.cpp	/^cs2sq::enResult cs2sq::add_symbols(void)$/;"	f	class:cs2sq
+add_symdata	makedb/cs2sq.cpp	/^cs2sq::enResult cs2sq::add_symdata(symdatalist sdlist, const char* lineid, idxcounter* idx)$/;"	f	class:cs2sq
+adjEdgesNum	showgraph/Layout/node_group.h	/^    inline unsigned int adjEdgesNum() const$/;"	f	class:NodeGroup
+adjust	showgraph/GraphView/edge_helper.cpp	/^EdgeHelper::adjust()$/;"	f	class:EdgeHelper
+adjust	showgraph/GraphView/edge_item.cpp	/^EdgeItem::adjust()$/;"	f	class:EdgeItem
+adjustAssociates	showgraph/GraphView/node_item.cpp	/^void NodeItem::adjustAssociates()$/;"	f	class:NodeItem
+adjustScrollBar	gui/graphdialog.cpp	/^void cqDialogGraph::adjustScrollBar(QScrollBar *scrollBar, double factor)$/;"	f	class:cqDialogGraph
+adjustStyles	showgraph/GraphView/edge_item.cpp	/^GEdge::adjustStyles()$/;"	f	class:GEdge
+adjustVerticalLevels	showgraph/Layout/layout.cpp	/^void AuxGraph::adjustVerticalLevels()$/;"	f	class:AuxGraph
+advance	showgraph/GraphView/node_item.cpp	/^bool NodeItem::advance()$/;"	f	class:NodeItem
+advanceNodes	showgraph/GraphView/graph_view.cpp	/^void GraphView::advanceNodes()$/;"	f	class:GraphView
+advanceView	showgraph/GraphView/graph_view.cpp	/^void GraphView::advanceView()$/;"	f	class:GraphView
+allocEvent	showgraph/Utils/mem_mgr.cpp	/^MemEventId MemInfo::allocEvent()$/;"	f	class:MemInfo
+allocReg	showgraph/Utils/mem_mgr.cpp	/^void MemInfo::allocReg( MemEventId n)$/;"	f	class:MemInfo
+alloc_counter	showgraph/Utils/mem_mgr.h	/^        MemEventId alloc_counter;$/;"	m	class:MemImpl::MemInfo
+alloc_event	showgraph/Utils/mem_entry.h	/^        MemEventId alloc_event;$/;"	m	class:MemImpl::Entry
+allocate	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::allocate( size_t size)$/;"	f	class:Mem::FixedPool
+allocateChunk	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool< Data>::allocateChunk()$/;"	f	class:Mem::FixedPool
+allocateEntry	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::allocateEntry()$/;"	f	class:MemImpl::Chunk
+alternate_background	showgraph/GraphView/node_item.h	/^    bool alternate_background; $/;"	m	class:NodeItem
+analyze	makedb/sqlbase.cpp	/^int sqlbase::analyze(const char* fn, const bool& debug)$/;"	f	class:sqlbase
+app_name	showgraph/Utils/conf.h	/^    QString app_name;$/;"	m	class:Conf
+areEqP	showgraph/Utils/misc.h	/^inline bool areEqP( const void *p1, const void *p2)$/;"	f
+areNotEqP	showgraph/Utils/misc.h	/^inline bool areNotEqP( const void *p1, const void *p2)$/;"	f
+argIndex	makedb/optlist.h	/^    int argIndex;$/;"	m	struct:option_t
+argument	makedb/optlist.h	/^    char *argument;$/;"	m	struct:option_t
+arrangeHorizontally	showgraph/Layout/layout.cpp	/^AuxGraph::arrangeHorizontally()$/;"	f	class:AuxGraph
+arrangeHorizontallyWOStable	showgraph/Layout/layout.cpp	/^void AuxGraph::arrangeHorizontallyWOStable()$/;"	f	class:AuxGraph
+arrangeHorizontallyWithStable	showgraph/Layout/layout.cpp	/^AuxGraph::arrangeHorizontallyWithStable( Rank min, Rank max)$/;"	f	class:AuxGraph
+arrangeLevel	showgraph/Layout/layout.cpp	/^void arrangeLevel( Level *level, GraphDir dir, bool commit_placement, bool first_pass)$/;"	f
+arrangeNodes	showgraph/Layout/layout.cpp	/^void Level::arrangeNodes( GraphDir dir, bool commit_placement, bool first_pass)$/;"	f	class:Level
+arrowSize	showgraph/GraphView/gview_impl.h	/^const qreal arrowSize = 10;$/;"	v
+assert	showgraph/Utils/asrt.h	/^inline void assert( bool asrt)$/;"	f
+assert	showgraph/Utils/asrt.h	/^template<class Excpt> inline void assert( bool asrt, Excpt e)$/;"	f
+assert	showgraph/Utils/asrt.h	/^template<class Excpt> inline void assert( bool assertion)$/;"	f
+assertd	showgraph/Utils/asrt.h	/^inline void assertd( bool asrt)$/;"	f
+assign	querylib/small_lib.cpp	/^void smartFILE::assign(FILE* fptr) {setme(fptr);}$/;"	f	class:smartFILE
+assign	querylib/small_lib.cpp	/^void smartFILE::assign(const smartFILE& sfp) {setme(sfp.m_fp);}$/;"	f	class:smartFILE
+attach	showgraph/Utils/list.h	/^    inline void attach( ListId list, MListItem< dim>* peer)$/;"	f	class:MListItem
+attach	showgraph/Utils/list.h	/^    inline void attach( MListItem< 1>* peer)$/;"	f	class:MListItem
+attachInDir	showgraph/Utils/list.h	/^    inline void attachInDir( ListId list, MListItem< dim>* p, ListDir dir)$/;"	f	class:MListItem
+attachInDir	showgraph/Utils/list.h	/^    inline void attachInDir( MListItem< 1>* p, ListDir dir)$/;"	f	class:MListItem
+autoCompleteFinished	gui/searchhandler.cpp	/^void searchhandler::autoCompleteFinished()$/;"	f	class:searchhandler
+autoCompleteStateChanged	gui/searchhandler.cpp	/^void searchhandler::autoCompleteStateChanged(int state)$/;"	f	class:searchhandler
+b	showgraph/Utils/mem_utest.cpp	/^    quint32 b;$/;"	m	class:MyPoolObj	file:
+barycenter	showgraph/Layout/aux_node.h	/^    qreal barycenter;$/;"	m	class:AuxNode
+barycenter	showgraph/Layout/node_group.h	/^    qreal barycenter;$/;"	m	class:NodeGroup
+bc	showgraph/Layout/aux_node.h	/^    inline qreal bc() const$/;"	f	class:AuxNode
+bc	showgraph/Layout/node_group.h	/^    inline qreal bc() const$/;"	f	class:NodeGroup
+bgcolor	gui/themes.cpp	/^	const char *bgcolor;$/;"	m	struct:__anon2	file:
+bold_border	showgraph/GraphView/node_item.h	/^    bool bold_border;$/;"	m	class:NodeItem
+bool_val	showgraph/Utils/conf.h	/^    bool bool_val;$/;"	m	union:OptValues
+borderRect	showgraph/GraphView/node_item.cpp	/^NodeItem::borderRect() const$/;"	f	class:NodeItem
+border_left	showgraph/Layout/node_group.h	/^    qreal border_left;$/;"	m	class:NodeGroup
+border_right	showgraph/Layout/node_group.h	/^    qreal border_right;$/;"	m	class:NodeGroup
+boundingRect	showgraph/GraphView/edge_helper.cpp	/^EdgeHelper::boundingRect() const$/;"	f	class:EdgeHelper
+boundingRect	showgraph/GraphView/edge_item.cpp	/^EdgeItem::boundingRect() const$/;"	f	class:EdgeItem
+boundingRect	showgraph/GraphView/node_item.cpp	/^NodeItem::boundingRect() const$/;"	f	class:NodeItem
+boxPath	showgraph/GraphView/node_item.cpp	/^inline QPainterPath boxPath( QRectF rect)$/;"	f
+boxRect	showgraph/GraphView/node_item.cpp	/^inline QRectF boxRect( QRectF rect)$/;"	f
+box_adjust	showgraph/GraphView/node_item.cpp	/^const qreal box_adjust = 5;$/;"	v
+brush	showgraph/GraphView/gstyle.h	/^inline QBrush GStyle::brush() const$/;"	f	class:GStyle
+brush_priv	showgraph/GraphView/gstyle.h	/^    QBrush brush_priv;$/;"	m	class:GStyle
+btmRight	showgraph/GraphView/edge_helper.h	/^    QPointF btmRight;$/;"	m	class:EdgeHelper
+btmRight	showgraph/GraphView/edge_item.h	/^    QPointF btmRight;$/;"	m	class:EdgeItem
+busy	showgraph/Utils/mem_chunk.h	/^        ChunkPos busy;$/;"	m	class:MemImpl::Chunk
+cAdditionalRules	gui/obsolete/highlighter.cpp	/^ void Highlighter::cAdditionalRules(const QString &text)$/;"	f	class:Highlighter
+cHighlightingRules	gui/obsolete/highlighter.h	/^     QVector<HighlightingRule> cHighlightingRules;$/;"	m	class:Highlighter
+called	showgraph/Utils/mem_utest.cpp	/^    bool *called;$/;"	m	class:MyPoolObj	file:
+calling_func	makedb/csdbparser.h	/^std::string calling_func;$/;"	m	class:sym_data
+calling_macro	makedb/csdbparser.h	/^std::string calling_macro;$/;"	m	class:sym_data
+cancel	showgraph/GraphView/style_edit.h	/^    QPushButton *cancel;$/;"	m	class:StyleEdit
+changeFillStyle	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::changeFillStyle()$/;"	f	class:StyleEdit
+changeLineStyle	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::changeLineStyle()$/;"	f	class:StyleEdit
+changeLineWidth	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::changeLineWidth( double width)$/;"	f	class:StyleEdit
+changeShape	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::changeShape()$/;"	f	class:StyleEdit
+changeStyleName	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::changeStyleName()$/;"	f	class:StyleEdit
+charAtPos	gui/obsolete/highlighter.cpp	/^ #define charAtPos(/;"	d	file:
+checkDelItems	showgraph/GraphView/graph_view.h	/^    inline void checkDelItems()$/;"	f	class:GraphView
+checkNodes	showgraph/Graph/edge.cpp	/^bool Edge::checkNodes( Node* _pred, Node* _succ)$/;"	f	class:Edge
+checkUpDown	gui/listhandler.cpp	/^void listhandler::checkUpDown(void)$/;"	f	class:listhandler
+check_fileExists	querylib/small_lib.cpp	/^bool check_fileExists(const char *fn)$/;"	f
+chomp	querylib/small_lib.cpp	/^const char* chomp(char* str)$/;"	f
+chr	makedb/csdbparser.cpp	/^int chr;$/;"	m	struct:__anon5	file:
+chr2enum	makedb/csdbparser.cpp	/^} chr2enum;$/;"	t	typeref:struct:__anon5	file:
+circlePath	showgraph/GraphView/node_item.cpp	/^inline QPainterPath circlePath( QRectF rect)$/;"	f
+circleRect	showgraph/GraphView/node_item.cpp	/^inline QRectF circleRect( QRectF rect)$/;"	f
+classA	showgraph/Utils/list_utest.cpp	/^class classA: public MListIface< classA, MListItem<LISTS_NUM>, LISTS_NUM>$/;"	c	file:
+classA	showgraph/Utils/utils_utest.cpp	/^    classA( const classA&){};$/;"	f	class:classA	file:
+classA	showgraph/Utils/utils_utest.cpp	/^    classA(){};$/;"	f	class:classA	file:
+classA	showgraph/Utils/utils_utest.cpp	/^class classA$/;"	c	file:
+classifyEdges	showgraph/Layout/layout.cpp	/^void AuxGraph::classifyEdges()$/;"	f	class:AuxGraph
+clear	makedb/csdbparser.cpp	/^void sym_data::clear(void)$/;"	f	class:sym_data
+clear	makedb/csdbparser.cpp	/^void symdata_pack::clear(void)$/;"	f	class:symdata_pack
+clear	querylib/small_lib.cpp	/^void tempbuf::clear(void) {*m_buffer = 0;}$/;"	f	class:tempbuf
+clear	showgraph/Graph/marker.h	/^inline void Marked::clear( MarkerIndex i)$/;"	f	class:Marked
+clear	showgraph/Graph/num.h	/^Numbered::clear( NumIndex i)$/;"	f	class:Numbered
+clearList	gui/fileviewer.cpp	/^void fileviewer::clearList()$/;"	f	class:fileviewer
+clearList	gui/listhandler.cpp	/^void listhandler::clearList()$/;"	f	class:listhandler
+clearMarkersInObjects	showgraph/Graph/graph.cpp	/^Graph::clearMarkersInObjects()$/;"	f	class:Graph
+clearNodesPriority	showgraph/GraphView/graph_view.cpp	/^void GGraph::clearNodesPriority()$/;"	f	class:GGraph
+clearNumerationsInObjects	showgraph/Graph/graph.cpp	/^Graph::clearNumerationsInObjects()$/;"	f	class:Graph
+clearSearch	showgraph/GraphView/graph_view.cpp	/^void GraphView::clearSearch()$/;"	f	class:GraphView
+clearUnusedMarkers	showgraph/Graph/marker.h	/^MarkerManager::clearUnusedMarkers( Marked *m_obj)$/;"	f	class:MarkerManager
+clearUnusedNumerations	showgraph/Graph/num.h	/^inline void NumManager::clearUnusedNumerations( Numbered *n_obj)$/;"	f	class:NumManager
+close_csdb	makedb/cs2sq.cpp	/^void cs2sq::close_csdb(void)$/;"	f	class:cs2sq
+close_db	makedb/cs2sq.cpp	/^void cs2sq::close_db(void)$/;"	f	class:cs2sq
+close_dbfile	querylib/sqlquery.cpp	/^void sqlquery::close_dbfile(void)$/;"	f	class:sqlquery
+close_file	makedb/csdbparser.cpp	/^void csdbparser::close_file(void)$/;"	f	class:csdbparser
+close_file	querylib/small_lib.cpp	/^void smartFILE::close_file(void)$/;"	f	class:smartFILE
+close_files	makedb/ctagread.cpp	/^void ctagread::close_files(void)$/;"	f	class:ctagread
+cls	makedb/ctagread.h	/^	std::string cls;$/;"	m	struct:__anon6
+codeEditor	gui/obsolete/CodeEditor.h	/^     CodeEditor *codeEditor;$/;"	m	class:LineNumberArea
+collateGrep	gui/searchhandler.cpp	/^void searchhandler::collateGrep(sqlqueryresultlist &result,$/;"	f	class:searchhandler
+color	showgraph/GraphView/style_edit.h	/^    QColor color;$/;"	m	class:ColorButton
+compare	gui/fileviewer.cpp	/^bool filedata::compare(const filedata& fd)$/;"	f	class:filedata
+compare	gui/searchhandler.cpp	/^int searchitem::compare(const searchitem& otheritem)$/;"	f	class:searchitem
+compareBc	showgraph/Layout/node_group.cpp	/^bool compareBc( AuxNode* node1,$/;"	f
+compareFilenameOnly	gui/fileviewer.cpp	/^bool filedata::compareFilenameOnly(const filedata& fd)$/;"	f	class:filedata
+compareGroups	showgraph/Layout/layout.cpp	/^bool compareGroups( NodeGroup* g1,$/;"	f
+compareOrders	showgraph/Layout/layout.cpp	/^bool compareOrders( AuxNode* node1,$/;"	f
+constchar	querylib/small_lib.cpp	/^const char* tempbuf::constchar(void)$/;"	f	class:tempbuf
+contains	showgraph/GraphView/node_item.cpp	/^bool NodeItem::contains(const QPointF &point) const$/;"	f	class:NodeItem
+contextMenuEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::contextMenuEvent( QContextMenuEvent * e)$/;"	f	class:GraphView
+convertToImage	showgraph/showgraph.cpp	/^QImage showgraph::convertToImage(QString grpxml)$/;"	f	class:showgraph
+cp1	showgraph/GraphView/edge_helper.h	/^    QPointF cp1;$/;"	m	class:EdgeHelper
+cp1	showgraph/GraphView/edge_item.h	/^    QPointF cp1;$/;"	m	class:EdgeItem
+cp2	showgraph/GraphView/edge_helper.h	/^    QPointF cp2;$/;"	m	class:EdgeHelper
+cp2	showgraph/GraphView/edge_item.h	/^    QPointF cp2;$/;"	m	class:EdgeItem
+cppFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat cppFormat;$/;"	m	class:Highlighter
+cpp_Bespin	gui/themes_gen.cpp	/^static const lexstyle cpp_Bespin[] = {$/;"	v	file:
+cpp_Black_board	gui/themes_gen.cpp	/^static const lexstyle cpp_Black_board[] = {$/;"	v	file:
+cpp_Choco	gui/themes_gen.cpp	/^static const lexstyle cpp_Choco[] = {$/;"	v	file:
+cpp_Deep_Black	gui/themes_gen.cpp	/^static const lexstyle cpp_Deep_Black[] = {$/;"	v	file:
+cpp_Eclipse_Default	gui/themes_gen.cpp	/^static const lexstyle cpp_Eclipse_Default[] = {$/;"	v	file:
+cpp_Hello_Kitty	gui/themes_gen.cpp	/^static const lexstyle cpp_Hello_Kitty[] = {$/;"	v	file:
+cpp_HotFudgeSundae	gui/themes_gen.cpp	/^static const lexstyle cpp_HotFudgeSundae[] = {$/;"	v	file:
+cpp_Mono_Industrial	gui/themes_gen.cpp	/^static const lexstyle cpp_Mono_Industrial[] = {$/;"	v	file:
+cpp_Monokai	gui/themes_gen.cpp	/^static const lexstyle cpp_Monokai[] = {$/;"	v	file:
+cpp_MossyLawn	gui/themes_gen.cpp	/^static const lexstyle cpp_MossyLawn[] = {$/;"	v	file:
+cpp_Navajo	gui/themes_gen.cpp	/^static const lexstyle cpp_Navajo[] = {$/;"	v	file:
+cpp_NotepadPlusPlus	gui/themes_gen.cpp	/^static const lexstyle cpp_NotepadPlusPlus[] = {$/;"	v	file:
+cpp_Obsidian	gui/themes_gen.cpp	/^static const lexstyle cpp_Obsidian[] = {$/;"	v	file:
+cpp_Plastic_Code_Wrap	gui/themes_gen.cpp	/^static const lexstyle cpp_Plastic_Code_Wrap[] = {$/;"	v	file:
+cpp_Ruby_Blue	gui/themes_gen.cpp	/^static const lexstyle cpp_Ruby_Blue[] = {$/;"	v	file:
+cpp_Solarized	gui/themes_gen.cpp	/^static const lexstyle cpp_Solarized[] = {$/;"	v	file:
+cpp_Solarized_light	gui/themes_gen.cpp	/^static const lexstyle cpp_Solarized_light[] = {$/;"	v	file:
+cpp_Twilight	gui/themes_gen.cpp	/^static const lexstyle cpp_Twilight[] = {$/;"	v	file:
+cpp_Vibrant_Ink	gui/themes_gen.cpp	/^static const lexstyle cpp_Vibrant_Ink[] = {$/;"	v	file:
+cpp_Zenburn	gui/themes_gen.cpp	/^static const lexstyle cpp_Zenburn[] = {$/;"	v	file:
+cpp_khaki	gui/themes_gen.cpp	/^static const lexstyle cpp_khaki[] = {$/;"	v	file:
+cpp_vim_Dark_Blue	gui/themes_gen.cpp	/^static const lexstyle cpp_vim_Dark_Blue[] = {$/;"	v	file:
+cppstyle	gui/themes_gen.cpp	/^static const langstyle cppstyle[] = {$/;"	v	file:
+cqDialogAbout	gui/aboutdialog.cpp	/^cqDialogAbout::cqDialogAbout(QWidget *parent)$/;"	f	class:cqDialogAbout
+cqDialogAbout	gui/aboutdialog.h	/^class cqDialogAbout : public QDialog$/;"	c
+cqDialogFileViewSettings	gui/fileviewsettingsdialog.cpp	/^cqDialogFileViewSettings::cqDialogFileViewSettings(QWidget *parent,$/;"	f	class:cqDialogFileViewSettings
+cqDialogFileViewSettings	gui/fileviewsettingsdialog.h	/^class cqDialogFileViewSettings : public QDialog$/;"	c
+cqDialogGraph	gui/graphdialog.cpp	/^cqDialogGraph::cqDialogGraph(QWidget *parent)$/;"	f	class:cqDialogGraph
+cqDialogGraph	gui/graphdialog.h	/^class cqDialogGraph : public QDialog$/;"	c
+createActions	showgraph/GraphView/graph_view.cpp	/^void GraphView::createActions()$/;"	f	class:GraphView
+createEdge	showgraph/Graph/agraph.h	/^inline Edge * AGraph::createEdge( int _id, Node *_pred, Node* _succ)$/;"	f	class:AGraph
+createEdge	showgraph/Graph/graph.cpp	/^Graph::createEdge( int _id, Node *_pred, Node* _succ)$/;"	f	class:Graph
+createEdge	showgraph/GraphView/graph_view.h	/^    bool createEdge;$/;"	m	class:GraphView
+createEdge	showgraph/GraphView/graph_view.h	/^    virtual Edge * createEdge( int _id, Node *_pred, Node* _succ)$/;"	f	class:GGraph
+createEdge	showgraph/Layout/aux_graph.h	/^    virtual Edge * createEdge( int _id, Node *_pred, Node* _succ)$/;"	f	class:AuxGraph
+createEdgeLabel	showgraph/GraphView/graph_view.cpp	/^void GGraph::createEdgeLabel( QPointF pos)$/;"	f	class:GGraph
+createEdgeLabel	showgraph/GraphView/graph_view.cpp	/^void GraphView::createEdgeLabel()$/;"	f	class:GraphView
+createEdgeLabelAct	showgraph/GraphView/graph_view.h	/^    QAction *createEdgeLabelAct;$/;"	m	class:GraphView
+createFontList	gui/fileviewer.cpp	/^void fileviewer::createFontList(void)$/;"	f	class:fileviewer
+createMenuForEdge	showgraph/GraphView/graph_view.cpp	/^QMenu* GraphView::createMenuForEdge( GEdge *e)$/;"	f	class:GraphView
+createMenuForNode	showgraph/GraphView/graph_view.cpp	/^QMenu* GraphView::createMenuForNode( GNode *n)$/;"	f	class:GraphView
+createMenus	showgraph/GraphView/graph_view.cpp	/^void GraphView::createMenus()$/;"	f	class:GraphView
+createNode	showgraph/Graph/agraph.h	/^inline Node * AGraph::createNode( int _id)$/;"	f	class:AGraph
+createNode	showgraph/Graph/graph.cpp	/^Graph::createNode( int _id)$/;"	f	class:Graph
+createNode	showgraph/GraphView/graph_view.h	/^    virtual Node * createNode( int _id)$/;"	f	class:GGraph
+createNode	showgraph/Layout/aux_graph.h	/^    virtual Node * createNode( int _id)$/;"	f	class:AuxGraph
+createPools	showgraph/Graph/agraph.h	/^    void createPools()$/;"	f	class:AGraph
+createPools	showgraph/Graph/graph.cpp	/^void Graph::createPools()$/;"	f	class:Graph
+createSESelected	showgraph/GraphView/graph_view.cpp	/^void GraphView::createSESelected()$/;"	f	class:GraphView
+createSelfEdge	showgraph/GraphView/graph_view.cpp	/^void GGraph::createSelfEdge()$/;"	f	class:GGraph
+createSelfEdgeAct	showgraph/GraphView/graph_view.h	/^    QAction *createSelfEdgeAct;$/;"	m	class:GraphView
+createWidget	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QWidget *CodeEditorWidgetPlugin::createWidget(QWidget *parent)$/;"	f	class:CodeEditorWidgetPlugin
+create_buf	makedb/csdbparser.cpp	/^void csdbparser::create_buf(int size)$/;"	f	class:csdbparser
+cs2sq	makedb/cs2sq.cpp	/^cs2sq::cs2sq()$/;"	f	class:cs2sq
+cs2sq	makedb/cs2sq.h	/^class cs2sq : public sqlbase$/;"	c
+csdbheader	makedb/csdbheader.cpp	/^csdbheader::csdbheader()$/;"	f	class:csdbheader
+csdbheader	makedb/csdbheader.cpp	/^csdbheader::csdbheader(tStr hdr)$/;"	f	class:csdbheader
+csdbheader	makedb/csdbheader.h	/^class csdbheader$/;"	c
+csdbparser	makedb/csdbparser.cpp	/^csdbparser::csdbparser()$/;"	f	class:csdbparser
+csdbparser	makedb/csdbparser.h	/^class csdbparser$/;"	c
+ctagread	makedb/ctagread.cpp	/^ctagread::ctagread()$/;"	f	class:ctagread
+ctagread	makedb/ctagread.h	/^class ctagread : public sqlbase$/;"	c
+cur_level	showgraph/Layout/aux_graph.h	/^    int cur_level; \/\/last processed level$/;"	m	class:AuxGraph
+cur_pass	showgraph/Layout/aux_graph.h	/^    int cur_pass; \/\/ current pass$/;"	m	class:AuxGraph
+currPos	showgraph/GraphView/graph_view.h	/^    inline QPointF currPos() const$/;"	f	class:GraphView
+curr_mode	showgraph/GraphView/edge_item.h	/^    EdgeMode curr_mode;$/;"	m	class:EdgeItem
+curr_pos	showgraph/GraphView/graph_view.h	/^    QPointF curr_pos;$/;"	m	class:GraphView
+data	showgraph/GraphView/graph_view.h	/^    NavEventData data;$/;"	m	class:NavEvent
+data	showgraph/Utils/list.h	/^    inline Data *data() const$/;"	f	class:ListItem
+data_p	showgraph/Utils/list.h	/^    Data *data_p;$/;"	m	class:ListItem
+deallocEvent	showgraph/Utils/mem_mgr.cpp	/^MemEventId MemInfo::deallocEvent()$/;"	f	class:MemInfo
+deallocReg	showgraph/Utils/mem_mgr.cpp	/^void MemInfo::deallocReg( MemEventId n)$/;"	f	class:MemInfo
+dealloc_counter	showgraph/Utils/mem_mgr.h	/^        MemEventId dealloc_counter;$/;"	m	class:MemImpl::MemInfo
+dealloc_event	showgraph/Utils/mem_entry.h	/^        MemEventId dealloc_event;$/;"	m	class:MemImpl::Entry
+deallocate	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::deallocate( void *ptr)$/;"	f	class:Mem::FixedPool
+deallocateChunk	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::deallocateChunk( MemImpl::Chunk< Data> *chunk)$/;"	f	class:Mem::FixedPool
+deallocateEntry	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::deallocateEntry( Entry<Data> *e)$/;"	f	class:MemImpl::Chunk
+debugPrint	showgraph/Graph/edge.cpp	/^Edge::debugPrint()$/;"	f	class:Edge
+debugPrint	showgraph/Graph/graph.cpp	/^Graph::debugPrint()$/;"	f	class:Graph
+debugPrint	showgraph/Graph/node.cpp	/^Node::debugPrint()$/;"	f	class:Node
+debugPrint	showgraph/Layout/aux_graph.h	/^    virtual void debugPrint()$/;"	f	class:AuxGraph
+debugPrint	showgraph/Layout/aux_node.h	/^    inline void debugPrint()$/;"	f	class:AuxNode
+decNumItems	showgraph/GraphView/gstyle.h	/^inline void GStyle::decNumItems()$/;"	f	class:GStyle
+decRefCount	showgraph/Utils/mem_obj.h	/^		inline void decRefCount()$/;"	f	class:Mem::Obj
+defBoolVal	showgraph/Utils/conf.h	/^    inline bool defBoolVal() const$/;"	f	class:Option
+def_values	showgraph/Utils/conf.h	/^    OptValues def_values;$/;"	m	class:Option
+defaultbgcolor	gui/themes.cpp	/^	const char *defaultbgcolor;$/;"	m	struct:__anon3	file:
+defaultfgcolor	gui/themes.cpp	/^	const char *defaultfgcolor;$/;"	m	struct:__anon3	file:
+defined	showgraph/Utils/conf.h	/^    bool defined;$/;"	m	class:Option
+deinit	showgraph/Utils/singleton.h	/^Single< T>::deinit()$/;"	f	class:Single
+del_edge_items	showgraph/GraphView/graph_view.h	/^    QList< EdgeItem* > del_edge_items;$/;"	m	class:GraphView
+del_node_items	showgraph/GraphView/graph_view.h	/^    QList< NodeItem* > del_node_items;$/;"	m	class:GraphView
+deleteEdge	showgraph/Graph/graph_inline.h	/^inline void Graph::deleteEdge( void *e)$/;"	f	class:Graph
+deleteEdgeInDir	showgraph/Graph/node_inline.h	/^Node::deleteEdgeInDir( GraphDir dir, Edge* edge)$/;"	f	class:Node
+deleteEdgeWithControls	showgraph/GraphView/graph_view.cpp	/^void GGraph::deleteEdgeWithControls( GEdge *edge)$/;"	f	class:GGraph
+deleteEdges	showgraph/GraphView/graph_view.cpp	/^void GGraph::deleteEdges()$/;"	f	class:GGraph
+deleteItemAct	showgraph/GraphView/graph_view.h	/^    QAction *deleteItemAct;$/;"	m	class:GraphView
+deleteItems	showgraph/GraphView/graph_view.cpp	/^GraphView::deleteItems()$/;"	f	class:GraphView
+deleteLaterEdgeItem	showgraph/GraphView/graph_view.h	/^    void deleteLaterEdgeItem( EdgeItem *item)$/;"	f	class:GraphView
+deleteLaterNodeItem	showgraph/GraphView/graph_view.h	/^    void deleteLaterNodeItem( NodeItem *item)$/;"	f	class:GraphView
+deleteLevels	showgraph/Layout/aux_graph.cpp	/^AuxGraph::deleteLevels()$/;"	f	class:AuxGraph
+deleteNode	showgraph/Graph/graph_inline.h	/^inline void Graph::deleteNode( void *n)$/;"	f	class:Graph
+deleteNodes	showgraph/GraphView/graph_view.cpp	/^void GGraph::deleteNodes()$/;"	f	class:GGraph
+deletePred	showgraph/Graph/node_inline.h	/^inline void Node::deletePred( Edge* edge)$/;"	f	class:Node
+deleteSelected	showgraph/GraphView/graph_view.cpp	/^void GraphView::deleteSelected()$/;"	f	class:GraphView
+deleteSucc	showgraph/Graph/node_inline.h	/^inline void Node::deleteSucc( Edge* edge)$/;"	f	class:Node
+deltaInDir	showgraph/GraphView/navigation.cpp	/^qreal NodeNav::deltaInDir( QPointF point, QPointF ref, NavDirection dir)$/;"	f	class:NodeNav
+desc	makedb/csdbparser.cpp	/^const char* desc;$/;"	m	struct:__anon5	file:
+descr	showgraph/Utils/conf.h	/^    QString descr;$/;"	m	class:Option
+destroy	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::destroy( void *ptr)$/;"	f	class:Mem::FixedPool
+destroyPools	showgraph/Graph/graph.cpp	/^void Graph::destroyPools()$/;"	f	class:Graph
+destroy_buf	makedb/csdbparser.cpp	/^void csdbparser::destroy_buf(void)$/;"	f	class:csdbparser
+detach	showgraph/Utils/list.h	/^    inline void detach( ListId list)$/;"	f	class:MListItem
+detach	showgraph/Utils/list.h	/^    inline void detach()$/;"	f	class:MListItem
+detachAll	showgraph/Utils/list.h	/^    inline void detachAll()$/;"	f	class:MListItem
+detachEdge	showgraph/Graph/graph_inline.h	/^inline void Graph::detachEdge( Edge * edge)$/;"	f	class:Graph
+detachFromGraph	showgraph/Graph/edge.h	/^	inline void detachFromGraph()$/;"	f	class:Edge
+detachFromGraph	showgraph/Graph/node_inline.h	/^inline void Node::detachFromGraph()$/;"	f	class:Node
+detachFromNode	showgraph/Graph/edge_inline.h	/^Edge::detachFromNode( GraphDir dir)$/;"	f	class:Edge
+detachNode	showgraph/Graph/graph_inline.h	/^inline void Graph::detachNode( Node* node)$/;"	f	class:Graph
+dialog	showgraph/GraphView/graph_view.h	/^        StyleEdit* dialog;$/;"	m	struct:GraphView::StyleEditInfo
+dialog	showgraph/GraphView/graph_view.h	/^    QProgressDialog *dialog;$/;"	m	class:GraphView
+dialog_ui	gui/aboutdialog.h	/^Ui::aboutDialog *dialog_ui;$/;"	m	class:cqDialogAbout
+dialog_ui	gui/fileviewsettingsdialog.h	/^Ui::fileViewSettingsDialog *dialog_ui;$/;"	m	class:cqDialogFileViewSettings
+dialog_ui	gui/graphdialog.h	/^Ui::DialogGraph *dialog_ui;$/;"	m	class:cqDialogGraph
+diamondPath	showgraph/GraphView/node_item.cpp	/^inline QPainterPath diamondPath( QRectF rect)$/;"	f
+diamondRect	showgraph/GraphView/node_item.cpp	/^inline QRectF diamondRect( QRectF rect)$/;"	f
+doGrep	gui/searchhandler.cpp	/^sqlqueryresultlist searchhandler::doGrep(const QString &fp)$/;"	f	class:searchhandler
+doLayout	showgraph/GraphView/graph_view.cpp	/^void GGraph::doLayout()$/;"	f	class:GGraph
+doLayout	showgraph/Layout/layout.cpp	/^void AuxGraph::doLayout()$/;"	f	class:AuxGraph
+doLayoutConcurrent	showgraph/Layout/layout.cpp	/^void AuxGraph::doLayoutConcurrent()$/;"	f	class:AuxGraph
+doLayoutSingle	showgraph/GraphView/graph_view.cpp	/^void GGraph::doLayoutSingle()$/;"	f	class:GGraph
+doc	showgraph/GraphView/node_item.h	/^    inline QTextDocument *doc() const$/;"	f	class:GNode
+domXml	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::domXml() const$/;"	f	class:CodeEditorWidgetPlugin
+dragEnterEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::dragEnterEvent(QDragEnterEvent *event)$/;"	f	class:GraphView
+dragMoveEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::dragMoveEvent( QDragMoveEvent *event)$/;"	f	class:GraphView
+drawBackground	showgraph/GraphView/graph_view.cpp	/^GraphView::drawBackground(QPainter *painter, const QRectF &rect)$/;"	f	class:GraphView
+dropEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::dropEvent(QDropEvent *event)$/;"	f	class:GraphView
+dst	showgraph/GraphView/edge_helper.h	/^EdgeHelper::dst() const$/;"	f	class:EdgeHelper
+dstP	showgraph/GraphView/edge_helper.h	/^    QPointF dstP;$/;"	m	class:EdgeHelper
+dstP	showgraph/GraphView/edge_item.h	/^    QPointF dstP;$/;"	m	class:EdgeItem
+dst_item	showgraph/GraphView/edge_helper.h	/^    NodeItem *dst_item;$/;"	m	class:EdgeHelper
+dummy	showgraph/Graph/agraph.h	/^    int dummy; \/\/Dummy class member$/;"	m	class:AGraph
+dummy	showgraph/Graph/agraph.h	/^    int dummy;$/;"	m	class:AEdge
+dummy	showgraph/Graph/agraph.h	/^    int dummy;$/;"	m	class:ANode
+dummy_ptr	showgraph/Utils/mem_chunk.h	/^        void *dummy_ptr; \/\/for alignment$/;"	m	class:MemImpl::Chunk
+edge	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::edge() const$/;"	f	class:EdgeIterIface
+edge	showgraph/Graph/node_iter.h	/^    inline Edge* edge() const { return edge_p;}$/;"	f	class:IterImplBase
+edge	showgraph/GraphView/edge_item.h	/^    inline GEdge* edge() const$/;"	f	class:EdgeItem
+edge	showgraph/GraphView/graph_view.h	/^        GEdge* edge;$/;"	m	struct:GraphView::StyleEditInfo
+edge	showgraph/Layout/aux_graph.h	/^        AuxEdge *edge; \/\/ Next edge$/;"	m	struct:AuxGraph::SimpleDfsStepInfo
+edge	showgraph/Layout/layout.cpp	/^    AuxEdge *edge; \/** Next edge *\/$/;"	m	struct:DfsStepInfo	file:
+edgeCount	showgraph/Graph/graph_inline.h	/^inline GraphNum Graph::edgeCount() const$/;"	f	class:Graph
+edgeInDir	showgraph/GraphView/navigation.cpp	/^NodeNav::edgeInDir( GEdge * edge, NavDirection dir) const$/;"	f	class:NodeNav
+edgeItemMenu	showgraph/GraphView/graph_view.h	/^    QMenu *edgeItemMenu;$/;"	m	class:GraphView
+edgeMenu	showgraph/GraphView/graph_view.h	/^    inline QMenu *edgeMenu() const$/;"	f	class:GraphView
+edgePool	showgraph/Graph/graph_inline.h	/^inline Pool *Graph::edgePool() const$/;"	f	class:Graph
+edge_next_id	showgraph/Graph/graph.h	/^    GraphUid edge_next_id;$/;"	m	class:Graph
+edge_num	showgraph/Graph/graph.h	/^    GraphNum edge_num;$/;"	m	class:Graph
+edge_num	showgraph/Layout/node_group.h	/^    unsigned int edge_num;$/;"	m	class:NodeGroup
+edge_p	showgraph/Graph/node_iter.h	/^    Edge *edge_p;$/;"	m	class:IterImplBase
+edge_p	showgraph/GraphView/edge_item.h	/^    GEdge* edge_p;$/;"	m	class:EdgeItem
+edge_pool	showgraph/Graph/graph.h	/^    Pool *edge_pool;$/;"	m	class:Graph
+edgesBegin	showgraph/Graph/node_inline.h	/^inline Node::EdgeIter Node::edgesBegin()$/;"	f	class:Node
+edgesEnd	showgraph/Graph/node_inline.h	/^inline Node::EdgeIter Node::edgesEnd()$/;"	f	class:Node
+editable	showgraph/GraphView/graph_view.h	/^    bool editable;$/;"	m	class:GraphView
+editableSwitchAct	showgraph/GraphView/graph_view.h	/^    QAction *editableSwitchAct;$/;"	m	class:GraphView
+elem	showgraph/Graph/edge_inline.h	/^inline QDomElement Edge::elem() const$/;"	f	class:Edge
+elem	showgraph/Graph/node_inline.h	/^inline QDomElement Node::elem() const$/;"	f	class:Node
+element	showgraph/Graph/edge.h	/^    QDomElement element;$/;"	m	class:Edge
+element	showgraph/Graph/node.h	/^    QDomElement element;$/;"	m	class:Node
+ellipsePath	showgraph/GraphView/node_item.cpp	/^inline QPainterPath ellipsePath( QRectF rect)$/;"	f
+ellipseRect	showgraph/GraphView/node_item.cpp	/^inline QRectF ellipseRect( QRectF rect)$/;"	f
+emptySelection	showgraph/GraphView/graph_view.h	/^    inline void emptySelection()$/;"	f	class:GGraph
+enHighlightCPP	gui/fileviewer.h	/^	enHighlightCPP,$/;"	e	enum:langtypes
+enHighlightCPP	gui/obsolete/highlighter.h	/^     enHighlightCPP = 0,$/;"	e	enum:enHighlightLang
+enHighlightGo	gui/fileviewer.h	/^	enHighlightGo$/;"	e	enum:langtypes
+enHighlightJava	gui/fileviewer.h	/^	enHighlightJava,$/;"	e	enum:langtypes
+enHighlightJava	gui/obsolete/highlighter.h	/^     enHighlightJava,$/;"	e	enum:enHighlightLang
+enHighlightLang	gui/obsolete/highlighter.h	/^ enum enHighlightLang$/;"	g
+enHighlightNone	gui/fileviewer.h	/^	enHighlightNone = 0,$/;"	e	enum:langtypes
+enHighlightPython	gui/fileviewer.h	/^	enHighlightPython,$/;"	e	enum:langtypes
+enHighlightPython	gui/obsolete/highlighter.h	/^     enHighlightPython$/;"	e	enum:enHighlightLang
+enHighlightRuby	gui/fileviewer.h	/^	enHighlightRuby,$/;"	e	enum:langtypes
+enResult	makedb/cs2sq.h	/^enum enResult$/;"	g	class:cs2sq
+enResult	makedb/csdbparser.h	/^enum enResult$/;"	g	class:csdbparser
+enResult	makedb/ctagread.h	/^enum enResult$/;"	g	class:ctagread
+enState	makedb/csdbparser.h	/^enum enState$/;"	g	class:csdbparser
+enSymType	makedb/csdbparser.h	/^enum enSymType$/;"	g	class:sym_data
+en_filereadstatus	querylib/sqlquery.h	/^enum en_filereadstatus$/;"	g	class:sqlquery
+en_queryType	querylib/sqlquery.h	/^enum en_queryType$/;"	g	class:sqlquery
+en_resultType	querylib/sqlquery.h	/^enum en_resultType$/;"	g	class:sqlqueryresultlist
+entry	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::entry( ChunkPos pos)$/;"	f	class:MemImpl::Chunk
+entryChunk	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool<Data>::entryChunk( MemImpl::Entry< Data> *e)$/;"	f	class:Mem::FixedPool
+entry_count	showgraph/Utils/mem_fixed_pool.h	/^        EntryNum entry_count;$/;"	m	class:Mem::FixedPool
+eraseNode	showgraph/GraphView/graph_view.cpp	/^void GraphViewHistory::eraseNode( GNode *n)$/;"	f	class:GraphViewHistory
+err	showgraph/Utils/print.h	/^    inline void err( const char* format, ...)$/;"	f	namespace:PrintUtils
+events	showgraph/GraphView/graph_view.h	/^    QList< NavEvent *> events; \/\/ List of events$/;"	m	class:GraphViewHistory
+exactmatch	gui/searchhandler.h	/^	bool exactmatch;$/;"	m	class:searchitem
+execHighlightRule	gui/obsolete/highlighter.cpp	/^ void Highlighter::execHighlightRule(const HighlightingRule &rule, const QString &text)$/;"	f	class:Highlighter
+execstmt	makedb/sqlbase.cpp	/^int sqlbase::execstmt(sqlite3_stmt* pstmt, const char* v1)$/;"	f	class:sqlbase
+execstmt	makedb/sqlbase.cpp	/^int sqlbase::execstmt(sqlite3_stmt* pstmt, const char* v1, const char* v2)$/;"	f	class:sqlbase
+execstmt	makedb/sqlbase.cpp	/^int sqlbase::execstmt(sqlite3_stmt* pstmt, const char* v1, const char* v2, const char* v3)$/;"	f	class:sqlbase
+execstmt	makedb/sqlbase.cpp	/^int sqlbase::execstmt(sqlite3_stmt* pstmt, const char* v1, const char* v2, const char* v3, const char* v4)$/;"	f	class:sqlbase
+execstmt	makedb/sqlbase.cpp	/^int sqlbase::execstmt(sqlite3_stmt* pstmt, const char* v1, const char* v2, const char* v3, const char* v4, const char* v5)$/;"	f	class:sqlbase
+extract_filename	querylib/small_lib.cpp	/^const char* extract_filename(const char* filepath)$/;"	f
+f_tags	makedb/ctagread.h	/^FILE* f_tags;$/;"	m	class:ctagread
+fgcolor	gui/themes.cpp	/^	const char *fgcolor;$/;"	m	struct:__anon2	file:
+fileToBeOpened	gui/fileviewer.cpp	/^void fileviewer::fileToBeOpened(QString filename, QString linenum)$/;"	f	class:fileviewer
+fileViewSettings_Triggered	gui/fileviewer.cpp	/^void fileviewer::fileViewSettings_Triggered(bool checked)$/;"	f	class:fileviewer
+file_sanity_check	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::file_sanity_check(const char *fn)$/;"	f	class:csdbparser
+filedata	gui/fileviewer.cpp	/^filedata::filedata()$/;"	f	class:filedata
+filedata	gui/fileviewer.cpp	/^filedata::filedata(const QString& fn, const QString& ln)$/;"	f	class:filedata
+filedata	gui/fileviewer.cpp	/^filedata::filedata(const filedata& fd)$/;"	f	class:filedata
+filedata	gui/fileviewer.h	/^class filedata$/;"	c
+fileexists	cli/main_cli.cpp	/^bool fileexists(const char* fn)$/;"	f
+fileexists	makedb/main.cpp	/^bool fileexists(const char* fn)$/;"	f
+filename	gui/fileviewer.h	/^	QString filename;$/;"	m	class:filedata
+filename	makedb/csdbparser.h	/^std::string filename;$/;"	m	class:symdata_pack
+filename	querylib/sqlquery.h	/^	tStr filename;$/;"	m	class:sqlqueryresult
+filepath	querylib/sqlquery.h	/^	tStr filepath;$/;"	m	class:sqlqueryresult
+fileviewer	gui/fileviewer.cpp	/^fileviewer::fileviewer(mainwindow* pmw)$/;"	f	class:fileviewer
+fileviewer	gui/fileviewer.h	/^class fileviewer : public QObject$/;"	c
+fill_check	showgraph/GraphView/style_edit.h	/^    QCheckBox *fill_check; $/;"	m	class:StyleEdit
+fill_color_button	showgraph/GraphView/style_edit.h	/^    ColorButton *fill_color_button;$/;"	m	class:StyleEdit
+fill_color_label	showgraph/GraphView/style_edit.h	/^    QLabel *fill_color_label;$/;"	m	class:StyleEdit
+filterterm	gui/searchhandler.h	/^	QString filterterm;$/;"	m	class:searchitem
+finalize	makedb/cs2sq.cpp	/^cs2sq::enResult cs2sq::finalize(void)$/;"	f	class:cs2sq
+finalize	makedb/ctagread.cpp	/^ctagread::enResult ctagread::finalize(void)$/;"	f	class:ctagread
+finalize	querylib/sqlquery.cpp	/^void tempstmt::finalize(void)$/;"	f	class:tempstmt
+findContext	showgraph/GraphView/graph_view.cpp	/^void GGraph::findContext()$/;"	f	class:GGraph
+findContext	showgraph/GraphView/graph_view.cpp	/^void GraphView::findContext()$/;"	f	class:GraphView
+findContextAct	showgraph/GraphView/graph_view.h	/^    QAction *findContextAct;$/;"	m	class:GraphView
+findEnterNodes	showgraph/Layout/layout.cpp	/^AuxGraph::findEnterNodes()$/;"	f	class:AuxGraph
+findFreeIndex	showgraph/Graph/marker.h	/^MarkerManager::findFreeIndex()$/;"	f	class:MarkerManager
+findFreeIndex	showgraph/Graph/num.h	/^inline NumIndex NumManager::findFreeIndex()$/;"	f	class:NumManager
+findNextFreeValue	showgraph/Graph/marker.h	/^MarkerManager::findNextFreeValue()$/;"	f	class:MarkerManager
+findNextFreeValue	showgraph/Graph/num.h	/^inline NumValue NumManager::findNextFreeValue()$/;"	f	class:NumManager
+findNextNodeWithText	showgraph/GraphView/graph_view.cpp	/^GraphView::findNextNodeWithText( QString &findStr,$/;"	f	class:GraphView
+findNodeById	showgraph/GraphView/graph_view.cpp	/^GNode* GraphView::findNodeById( int id)$/;"	f	class:GraphView
+findNodeByLabel	showgraph/GraphView/graph_view.cpp	/^GNode* GraphView::findNodeByLabel( QString label)$/;"	f	class:GraphView
+findPrevNodeWithText	showgraph/GraphView/graph_view.cpp	/^GraphView::findPrevNodeWithText( QString &findStr,$/;"	f	class:GraphView
+firstBusyChunk	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool< Data>::firstBusyChunk()$/;"	f	class:Mem::FixedPool
+firstBusyEntry	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::firstBusyEntry()$/;"	f	class:MemImpl::Chunk
+firstEdge	showgraph/Graph/agraph.h	/^    inline AEdge* firstEdge() $/;"	f	class:AGraph
+firstEdge	showgraph/Graph/graph_inline.h	/^inline Edge* Graph::firstEdge() $/;"	f	class:Graph
+firstEdge	showgraph/GraphView/graph_view.h	/^    inline GEdge* firstEdge() $/;"	f	class:GGraph
+firstEdge	showgraph/Layout/aux_graph.h	/^    inline AuxEdge* firstEdge() $/;"	f	class:AuxGraph
+firstEdgeInDir	showgraph/Graph/agraph.h	/^ANode::firstEdgeInDir( GraphDir dir)$/;"	f	class:ANode
+firstEdgeInDir	showgraph/Graph/node_inline.h	/^inline Edge* Node::firstEdgeInDir( GraphDir dir)$/;"	f	class:Node
+firstEdgeInDir	showgraph/GraphView/node_item.h	/^    inline GEdge* firstEdgeInDir( GraphDir dir)$/;"	f	class:GNode
+firstEdgeInDir	showgraph/Layout/aux_graph.h	/^AuxNode::firstEdgeInDir( GraphDir dir)$/;"	f	class:AuxNode
+firstEdgeInSector	showgraph/GraphView/navigation.cpp	/^NodeNav::firstEdgeInSector() const$/;"	f	class:NodeNav
+firstNode	showgraph/Graph/agraph.h	/^    inline ANode* firstNode()$/;"	f	class:AGraph
+firstNode	showgraph/Graph/graph_inline.h	/^inline Node* Graph::firstNode()$/;"	f	class:Graph
+firstNode	showgraph/GraphView/graph_view.h	/^    inline GNode* firstNode()$/;"	f	class:GGraph
+firstNode	showgraph/Layout/aux_graph.h	/^    inline AuxNode* firstNode()$/;"	f	class:AuxGraph
+firstPred	showgraph/Graph/agraph.h	/^ANode::firstPred()$/;"	f	class:ANode
+firstPred	showgraph/Graph/node_inline.h	/^inline Edge* Node::firstPred()$/;"	f	class:Node
+firstPred	showgraph/GraphView/node_item.h	/^    inline GEdge* firstPred()$/;"	f	class:GNode
+firstPred	showgraph/Layout/aux_graph.h	/^AuxNode::firstPred()$/;"	f	class:AuxNode
+firstSucc	showgraph/Graph/agraph.h	/^ANode::firstSucc()$/;"	f	class:ANode
+firstSucc	showgraph/Graph/node_inline.h	/^inline Edge* Node::firstSucc()$/;"	f	class:Node
+firstSucc	showgraph/GraphView/node_item.h	/^    inline GEdge* firstSucc()$/;"	f	class:GNode
+firstSucc	showgraph/Layout/aux_graph.h	/^AuxNode::firstSucc()$/;"	f	class:AuxNode
+first_chunk	showgraph/Utils/mem_fixed_pool.h	/^        MemImpl::Chunk< Data> *first_chunk;$/;"	m	class:Mem::FixedPool
+first_edge	showgraph/Graph/graph.h	/^    Edge* first_edge;$/;"	m	class:Graph
+first_edge	showgraph/Graph/node.h	/^    Edge *first_edge[ GRAPH_DIRS_NUM];$/;"	m	class:Node
+first_node	showgraph/Graph/graph.h	/^    Node* first_node;$/;"	m	class:Graph
+floatVal	showgraph/Utils/conf.h	/^    inline qreal floatVal() const$/;"	f	class:Option
+float_val	showgraph/Utils/conf.h	/^    qreal float_val;$/;"	m	union:OptValues
+focusEvent	showgraph/GraphView/graph_view.h	/^    inline void focusEvent( GNode *n)$/;"	f	class:GraphViewHistory
+focusOnNode	showgraph/GraphView/graph_view.cpp	/^void GraphView::focusOnNode( GNode *n, bool gen_event)$/;"	f	class:GraphView
+focusOutEvent	showgraph/GraphView/node_item.cpp	/^void NodeItem::focusOutEvent(QFocusEvent *event)$/;"	f	class:NodeItem
+fontSelectionTemporary	gui/fileviewer.cpp	/^void fileviewer::fontSelectionTemporary(const QString &fonttxt)$/;"	f	class:fileviewer
+fontstyle	gui/themes.cpp	/^	int fontstyle;$/;"	m	struct:__anon2	file:
+foreachEdge	showgraph/Graph/graph_iface.h	/^#  define foreachEdge(/;"	d
+foreachNode	showgraph/Graph/graph_iface.h	/^#  define foreachNode(/;"	d
+foreachPred	showgraph/Graph/graph_iface.h	/^#  define foreachPred(/;"	d
+foreachSucc	showgraph/Graph/graph_iface.h	/^#  define foreachSucc(/;"	d
+format	gui/obsolete/highlighter.h	/^         QTextCharFormat format;$/;"	m	struct:Highlighter::HighlightingRule
+freeMarker	showgraph/Graph/marker.h	/^inline void MarkerManager::freeMarker( Marker m)$/;"	f	class:MarkerManager
+freeNum	showgraph/Graph/num.h	/^inline void NumManager::freeNum( Numeration n)$/;"	f	class:NumManager
+free_chunk	showgraph/Utils/mem_fixed_pool.h	/^        MemImpl::Chunk< Data> *free_chunk;$/;"	m	class:Mem::FixedPool
+free_entry	showgraph/Utils/mem_chunk.h	/^        ChunkPos free_entry;$/;"	m	class:MemImpl::Chunk
+functionFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat functionFormat;$/;"	m	class:Highlighter
+get	querylib/small_lib.cpp	/^FILE* smartFILE::get(void) {return m_fp;}$/;"	f	class:smartFILE
+get	querylib/small_lib.cpp	/^char* tempbuf::get(void) {return m_buffer;}$/;"	f	class:tempbuf
+get	querylib/sqlquery.cpp	/^sqlite3_stmt* tempstmt::get(void)$/;"	f	class:tempstmt
+getBasePath	makedb/csdbparser.cpp	/^const char* csdbparser::getBasePath(void)$/;"	f	class:csdbparser
+getHListOfClassIDs	makedb/ctagread.cpp	/^ctagread::enResult ctagread::getHListOfClassIDs(strctagIDList* idlist, const char* v1, std::vector<stClsID> *listClsHist)$/;"	f	class:ctagread
+getInt	querylib/small_lib.cpp	/^long unsigned int idxcounter::getInt(void) const {return m_ctr;}$/;"	f	class:idxcounter
+getLangFilePath	gui/langtable.cpp	/^QString langtable::getLangFilePath(const QString& lang)$/;"	f	class:langtable
+getLangNameList	gui/langtable.cpp	/^QStringList langtable::getLangNameList(void)$/;"	f	class:langtable
+getListOfClassIDs	makedb/ctagread.cpp	/^ctagread::enResult ctagread::getListOfClassIDs(strctagIDList* idlist, const char* v1)$/;"	f	class:ctagread
+getListOfSymIDs	makedb/ctagread.cpp	/^ctagread::enResult ctagread::getListOfSymIDs(sqlite3_stmt* pstmt, strctagIDList* idlist, const char* v1, const char* v2, const char* v3)$/;"	f	class:ctagread
+getStr	querylib/small_lib.cpp	/^const char* idxcounter::getStr(void) const {return m_buf;}$/;"	f	class:idxcounter
+getStrSize	querylib/small_lib.cpp	/^int idxcounter::getStrSize(void) const {return strlen(m_buf);}$/;"	f	class:idxcounter
+getThemesList	gui/themes.cpp	/^QStringList themes::getThemesList(void)$/;"	f	class:themes
+getTypeChar	makedb/csdbparser.cpp	/^const char sym_data::getTypeChar(void)$/;"	f	class:sym_data
+getTypeDesc	makedb/csdbparser.cpp	/^const char* sym_data::getTypeDesc(void)$/;"	f	class:sym_data
+get_base_path	makedb/csdbheader.cpp	/^tStr csdbheader::get_base_path(void)$/;"	f	class:csdbheader
+get_csdbpError	makedb/cs2sq.h	/^csdbparser::enResult get_csdbpError(void) {return m_csdbpLastErr;}$/;"	f	class:cs2sq
+get_last_part	querylib/small_lib.cpp	/^char* get_last_part(char* str, int c)$/;"	f
+get_next_srcfil	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::get_next_srcfil(std::string* srcfil)$/;"	f	class:csdbparser
+get_next_symbol	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::get_next_symbol(symdata_pack* pack)$/;"	f	class:csdbparser
+get_param_list	makedb/csdbheader.cpp	/^tVecStr csdbheader::get_param_list(void)$/;"	f	class:csdbheader
+get_trailer_start	makedb/csdbheader.cpp	/^long int csdbheader::get_trailer_start(void)$/;"	f	class:csdbheader
+get_version	makedb/csdbheader.cpp	/^long int csdbheader::get_version(void)$/;"	f	class:csdbheader
+goBackInSearchMemory	gui/searchhandler.cpp	/^void searchhandler::goBackInSearchMemory(void)$/;"	f	class:searchhandler
+goForwardInSearchMemory	gui/searchhandler.cpp	/^void searchhandler::goForwardInSearchMemory(void)$/;"	f	class:searchhandler
+graph	showgraph/Graph/edge_inline.h	/^inline Graph * Edge::graph() const$/;"	f	class:Edge
+graph	showgraph/Graph/node_inline.h	/^inline Graph * Node::graph() const$/;"	f	class:Node
+graph	showgraph/GraphView/edge_item.cpp	/^GEdge::graph() const$/;"	f	class:GEdge
+graph	showgraph/GraphView/graph_view.h	/^    inline GGraph *graph() const$/;"	f	class:GraphView
+graph	showgraph/GraphView/node_item.cpp	/^GGraph* GNode::graph() const$/;"	f	class:GNode
+graph_p	showgraph/Graph/edge.h	/^    Graph * graph_p; \/\/Graph$/;"	m	class:Edge
+graph_p	showgraph/Graph/node.h	/^    Graph * graph_p;\/**< Pointer to graph *\/$/;"	m	class:Node
+graph_p	showgraph/GraphView/graph_view.h	/^    GGraph * graph_p;$/;"	m	class:GraphView
+group	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::group() const$/;"	f	class:CodeEditorWidgetPlugin
+group_weight	showgraph/Layout/node_group.h	/^    float group_weight;$/;"	m	class:NodeGroup
+gstyle	showgraph/GraphView/style_edit.h	/^    GStyle *gstyle;$/;"	m	class:StyleEdit
+handleFileCannotBeOpenedCase	gui/fileviewer.cpp	/^void fileviewer::handleFileCannotBeOpenedCase(void)$/;"	f	class:fileviewer
+hasSmoothFocus	showgraph/GraphView/graph_view.h	/^    inline bool hasSmoothFocus() const$/;"	f	class:GraphView
+height	showgraph/GraphView/node_item.h	/^    virtual inline double height() const$/;"	f	class:GNode
+height	showgraph/Layout/aux_graph.h	/^    inline qreal height() const$/;"	f	class:Level
+height	showgraph/Layout/aux_node.h	/^    virtual double height() const$/;"	f	class:AuxNode
+helper	showgraph/GraphView/graph_view.h	/^    EdgeHelper *helper;$/;"	m	class:GraphView
+highlight	showgraph/GraphView/node_item.h	/^    inline void highlight()$/;"	f	class:NodeItem
+highlightBlock	gui/obsolete/highlighter.cpp	/^ void Highlighter::highlightBlock(const QString &text)$/;"	f	class:Highlighter
+highlightCurrentLine	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::highlightCurrentLine()$/;"	f	class:CodeEditor
+highlightLine	gui/fileviewer.cpp	/^void fileviewer::highlightLine(unsigned int num)$/;"	f	class:fileviewer
+highlightLine	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::highlightLine(int linenum)$/;"	f	class:CodeEditor
+icon	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QIcon CodeEditorWidgetPlugin::icon() const$/;"	f	class:CodeEditorWidgetPlugin
+id	makedb/cs2sq.h	/^	std::string id;$/;"	m	struct:__anon4
+id	makedb/ctagread.h	/^	std::string id;$/;"	m	struct:__anon6
+id	showgraph/Graph/edge_inline.h	/^inline GraphUid Edge::id() const$/;"	f	class:Edge
+id	showgraph/Graph/node_inline.h	/^inline GraphUid Node::id() const$/;"	f	class:Node
+idxcounter	querylib/small_lib.cpp	/^idxcounter::idxcounter():m_ctr(0) {}$/;"	f	class:idxcounter
+idxcounter	querylib/small_lib.cpp	/^idxcounter::idxcounter(const idxcounter& idxc)$/;"	f	class:idxcounter
+idxcounter	querylib/small_lib.h	/^class idxcounter$/;"	c
+impl	showgraph/Graph/node_iter.h	/^    EdgeIterImpl impl;$/;"	m	class:EdgeIterIface
+incNumItems	showgraph/GraphView/gstyle.h	/^inline void GStyle::incNumItems()$/;"	f	class:GStyle
+incRefCount	showgraph/Utils/mem_obj.h	/^		inline void incRefCount()$/;"	f	class:Mem::Obj
+includeFile	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::includeFile() const$/;"	f	class:CodeEditorWidgetPlugin
+index	showgraph/Graph/marker.h	/^    MarkerIndex index;$/;"	m	class:Marker
+index	showgraph/Graph/num.h	/^    NumIndex index;$/;"	m	class:Numeration
+init	gui/fileviewer.cpp	/^void fileviewer::init(void)$/;"	f	class:fileviewer
+init	gui/listhandler.cpp	/^void listhandler::init(void)$/;"	f	class:listhandler
+init	gui/mainwindow.cpp	/^void mainwindow::init(void)$/;"	f	class:mainwindow
+init	gui/searchhandler.cpp	/^void searchhandler::init(void)$/;"	f	class:searchhandler
+init	showgraph/Layout/node_group.h	/^    inline void init()$/;"	f	class:NodeGroup
+init	showgraph/Utils/singleton.h	/^Single< T>::init()$/;"	f	class:Single
+initLevels	showgraph/Layout/aux_graph.cpp	/^AuxGraph::initLevels( Rank max_level)$/;"	f	class:AuxGraph
+initialize	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ void CodeEditorWidgetPlugin::initialize(QDesignerFormEditorInterface * \/* core *\/)$/;"	f	class:CodeEditorWidgetPlugin
+initialized	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.h	/^     bool initialized;$/;"	m	class:CodeEditorWidgetPlugin
+insertLabelNode	showgraph/GraphView/edge_item.cpp	/^GEdge::insertLabelNode( QPointF pos)$/;"	f	class:GEdge
+insertNode	showgraph/Graph/agraph.h	/^    virtual ANode *insertNode()$/;"	f	class:AEdge
+insertNode	showgraph/Graph/edge_inline.h	/^Edge::insertNode()$/;"	f	class:Edge
+insertNode	showgraph/GraphView/edge_item.cpp	/^GEdge::insertNode()$/;"	f	class:GEdge
+insertNode	showgraph/Layout/aux_edge.h	/^    inline AuxNode *insertNode()$/;"	f	class:AuxEdge
+insertNodeAct	showgraph/GraphView/graph_view.h	/^    QAction *insertNodeAct;$/;"	m	class:GraphView
+insertNodeOnCenter	showgraph/GraphView/graph_view.cpp	/^void GraphView::insertNodeOnCenter()$/;"	f	class:GraphView
+instance	showgraph/Utils/singleton.h	/^Single< T>::instance()$/;"	f	class:Single
+instance_p	showgraph/Utils/singleton.h	/^    static T* instance_p; $/;"	m	class:Single
+instance_p	showgraph/Utils/singleton.h	/^template < class T> T *Single<T>::instance_p = 0;                                       $/;"	m	class:Single
+intVal	showgraph/Utils/conf.h	/^    inline int intVal() const$/;"	f	class:Option
+int_val	showgraph/Utils/conf.h	/^    int int_val;$/;"	m	union:OptValues
+interleaves	showgraph/Layout/node_group.h	/^    inline bool interleaves( NodeGroup *grp) const$/;"	f	class:NodeGroup
+invalidateRanking	showgraph/Layout/aux_graph.h	/^    inline void invalidateRanking()$/;"	f	class:AuxGraph
+inverted	showgraph/Layout/layout.cpp	/^    bool inverted; \/** If we have already processed preds and *\/$/;"	m	struct:DfsStepInfo	file:
+irId	showgraph/GraphView/node_item.h	/^	inline GraphNum irId() const$/;"	f	class:GNode
+ir_id	showgraph/GraphView/node_item.h	/^    GraphNum ir_id;$/;"	m	class:GNode
+isAbsolutePath	querylib/small_lib.cpp	/^bool isAbsolutePath(tStr fp)$/;"	f
+isBack	showgraph/Layout/aux_edge.h	/^    inline bool isBack() const$/;"	f	class:AuxEdge
+isCSDBFileOpen	makedb/cs2sq.h	/^bool isCSDBFileOpen(void)  {return m_csdbp.isFileOpen();}$/;"	f	class:cs2sq
+isContainer	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ bool CodeEditorWidgetPlugin::isContainer() const$/;"	f	class:CodeEditorWidgetPlugin
+isContext	showgraph/GraphView/graph_view.h	/^    inline bool isContext() const$/;"	f	class:GraphView
+isCreateEdge	showgraph/GraphView/graph_view.h	/^    inline bool isCreateEdge() const$/;"	f	class:GraphView
+isDBOpen	querylib/sqlquery.h	/^	bool isDBOpen(void) {return (m_db != NULL);}$/;"	f	class:sqlquery
+isDefault	showgraph/GraphView/gstyle.h	/^inline bool GStyle::isDefault() const$/;"	f	class:GStyle
+isDefined	showgraph/Utils/conf.h	/^    inline bool isDefined() const$/;"	f	class:Option
+isDirApplicable	showgraph/GraphView/navigation.cpp	/^bool NodeNav::isDirApplicable( NavDirection dir, NavSector s)$/;"	f	class:NodeNav
+isEdgeControl	showgraph/Layout/aux_node.h	/^    inline bool isEdgeControl() const$/;"	f	class:AuxNode
+isEdgeInSector	showgraph/GraphView/navigation.cpp	/^bool NodeNav::isEdgeInSector( GEdge * edge) const$/;"	f	class:NodeNav
+isEdgeLabel	showgraph/Layout/aux_node.h	/^    inline bool isEdgeLabel() const$/;"	f	class:AuxNode
+isEditable	showgraph/GraphView/graph_view.h	/^    inline bool isEditable() const$/;"	f	class:GraphView
+isEmpty	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::isEmpty() const$/;"	f	class:MemImpl::Chunk
+isFileOpen	makedb/csdbparser.h	/^bool isFileOpen(void) {return (m_fp != NULL);}$/;"	f	class:csdbparser
+isFixed	showgraph/Layout/aux_edge.h	/^    inline bool isFixed() const$/;"	f	class:AuxEdge
+isFocus	showgraph/GraphView/graph_view.h	/^    bool isFocus() const$/;"	f	class:NavEvent
+isForPlacement	showgraph/Layout/aux_node.h	/^    inline bool isForPlacement() const$/;"	f	class:AuxNode
+isFree	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::isFree() const$/;"	f	class:MemImpl::Chunk
+isHorizontal	showgraph/GraphView/visible_edge.cpp	/^bool VEdge::isHorizontal() const$/;"	f	class:VEdge
+isInitialized	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ bool CodeEditorWidgetPlugin::isInitialized() const$/;"	f	class:CodeEditorWidgetPlugin
+isInverted	showgraph/Layout/aux_edge.h	/^    inline bool isInverted() const$/;"	f	class:AuxEdge
+isMarked	showgraph/Graph/marker.h	/^inline bool Marked::isMarked( Marker marker)$/;"	f	class:Marked
+isNodeInFocus	showgraph/GraphView/node_item.cpp	/^bool GNode::isNodeInFocus() const$/;"	f	class:GNode
+isNotNullP	showgraph/Utils/misc.h	/^inline bool isNotNullP( const void *pointer)$/;"	f
+isNullP	showgraph/Utils/misc.h	/^inline bool isNullP( const void *pointer)$/;"	f
+isNumbered	showgraph/Graph/num.h	/^Numbered::isNumbered( Numeration num)$/;"	f	class:Numbered
+isPointInDir	showgraph/GraphView/navigation.cpp	/^bool NodeNav::isPointInDir( QPointF point, QPointF ref, NavDirection dir)$/;"	f	class:NodeNav
+isPseudo	showgraph/Layout/aux_node.h	/^    inline bool isPseudo() const$/;"	f	class:AuxNode
+isSelf	showgraph/Layout/aux_edge.h	/^    inline bool isSelf() const$/;"	f	class:AuxEdge
+isSet	showgraph/Utils/conf.h	/^    inline int isSet() const$/;"	f	class:Option
+isShowContextMenus	showgraph/GraphView/graph_view.h	/^    inline bool isShowContextMenus() const$/;"	f	class:GraphView
+isSimple	showgraph/Layout/aux_node.h	/^    inline bool isSimple() const$/;"	f	class:AuxNode
+isStable	showgraph/Layout/aux_node.h	/^    inline bool isStable() const$/;"	f	class:AuxNode
+isStartNode	showgraph/Layout/layout.cpp	/^static bool isStartNode( AuxNode *n)$/;"	f	file:
+isTextShown	showgraph/GraphView/node_item.h	/^	inline bool isTextShown() const$/;"	f	class:GNode
+isValueBusy	showgraph/Graph/marker.h	/^MarkerManager::isValueBusy( MarkerValue val)$/;"	f	class:MarkerManager
+isValueBusy	showgraph/Graph/num.h	/^inline bool NumManager::isValueBusy( NumValue val)$/;"	f	class:NumManager
+isVertical	showgraph/GraphView/visible_edge.cpp	/^bool VEdge::isVertical() const$/;"	f	class:VEdge
+is_busy	showgraph/Utils/mem_entry.h	/^        bool is_busy;$/;"	m	class:MemImpl::Entry
+is_default	showgraph/GraphView/gstyle.h	/^    bool is_default;$/;"	m	class:GStyle
+is_for_placement	showgraph/Layout/aux_node.h	/^    bool is_for_placement;$/;"	m	class:AuxNode
+is_pred	showgraph/Graph/node_iter.h	/^    bool is_pred;$/;"	m	class:UnDirIterImpl
+is_used	showgraph/Graph/marker.h	/^    bool is_used[ MAX_GRAPH_MARKERS];$/;"	m	class:MarkerManager
+is_used	showgraph/Graph/num.h	/^    bool is_used[ MAX_NUMERATIONS];$/;"	m	class:NumManager
+isempty	querylib/small_lib.cpp	/^bool tempbuf::isempty(void) const {return (*m_buffer == 0);}$/;"	f	class:tempbuf
+it	showgraph/GraphView/graph_view.h	/^    QList< NavEvent *>::Iterator it; \/\/ Iterator to hold current position in list$/;"	m	class:GraphViewHistory
+item	showgraph/GraphView/edge_item.h	/^    inline EdgeItem *item() const$/;"	f	class:GEdge
+item	showgraph/GraphView/node_item.h	/^    inline NodeItem* item() const$/;"	f	class:GNode
+itemChange	showgraph/GraphView/edge_item.cpp	/^EdgeItem::itemChange( GraphicsItemChange change, const QVariant &value)$/;"	f	class:EdgeItem
+itemChange	showgraph/GraphView/node_item.cpp	/^QVariant NodeItem::itemChange( GraphicsItemChange change, const QVariant &value)$/;"	f	class:NodeItem
+item_p	showgraph/GraphView/edge_item.h	/^    EdgeItem *item_p;$/;"	m	class:GEdge
+item_p	showgraph/GraphView/node_item.h	/^    NodeItem *item_p; $/;"	m	class:GNode
+javaHighlightingRules	gui/obsolete/highlighter.h	/^     QVector<HighlightingRule> javaHighlightingRules;$/;"	m	class:Highlighter
+java_Bespin	gui/themes_gen.cpp	/^static const lexstyle java_Bespin[] = {$/;"	v	file:
+java_Black_board	gui/themes_gen.cpp	/^static const lexstyle java_Black_board[] = {$/;"	v	file:
+java_Choco	gui/themes_gen.cpp	/^static const lexstyle java_Choco[] = {$/;"	v	file:
+java_Deep_Black	gui/themes_gen.cpp	/^static const lexstyle java_Deep_Black[] = {$/;"	v	file:
+java_Eclipse_Default	gui/themes_gen.cpp	/^static const lexstyle java_Eclipse_Default[] = {$/;"	v	file:
+java_Hello_Kitty	gui/themes_gen.cpp	/^static const lexstyle java_Hello_Kitty[] = {$/;"	v	file:
+java_HotFudgeSundae	gui/themes_gen.cpp	/^static const lexstyle java_HotFudgeSundae[] = {$/;"	v	file:
+java_Mono_Industrial	gui/themes_gen.cpp	/^static const lexstyle java_Mono_Industrial[] = {$/;"	v	file:
+java_Monokai	gui/themes_gen.cpp	/^static const lexstyle java_Monokai[] = {$/;"	v	file:
+java_MossyLawn	gui/themes_gen.cpp	/^static const lexstyle java_MossyLawn[] = {$/;"	v	file:
+java_Navajo	gui/themes_gen.cpp	/^static const lexstyle java_Navajo[] = {$/;"	v	file:
+java_NotepadPlusPlus	gui/themes_gen.cpp	/^static const lexstyle java_NotepadPlusPlus[] = {$/;"	v	file:
+java_Obsidian	gui/themes_gen.cpp	/^static const lexstyle java_Obsidian[] = {$/;"	v	file:
+java_Plastic_Code_Wrap	gui/themes_gen.cpp	/^static const lexstyle java_Plastic_Code_Wrap[] = {$/;"	v	file:
+java_Ruby_Blue	gui/themes_gen.cpp	/^static const lexstyle java_Ruby_Blue[] = {$/;"	v	file:
+java_Solarized	gui/themes_gen.cpp	/^static const lexstyle java_Solarized[] = {$/;"	v	file:
+java_Solarized_light	gui/themes_gen.cpp	/^static const lexstyle java_Solarized_light[] = {$/;"	v	file:
+java_Twilight	gui/themes_gen.cpp	/^static const lexstyle java_Twilight[] = {$/;"	v	file:
+java_Vibrant_Ink	gui/themes_gen.cpp	/^static const lexstyle java_Vibrant_Ink[] = {$/;"	v	file:
+java_Zenburn	gui/themes_gen.cpp	/^static const lexstyle java_Zenburn[] = {$/;"	v	file:
+java_khaki	gui/themes_gen.cpp	/^static const lexstyle java_khaki[] = {$/;"	v	file:
+java_vim_Dark_Blue	gui/themes_gen.cpp	/^static const lexstyle java_vim_Dark_Blue[] = {$/;"	v	file:
+javastyle	gui/themes_gen.cpp	/^static const langstyle javastyle[] = {$/;"	v	file:
+keyPressEvent	showgraph/GraphView/edge_item.cpp	/^EdgeItem::keyPressEvent(QKeyEvent *event)$/;"	f	class:EdgeItem
+keyPressEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::keyPressEvent(QKeyEvent *event)$/;"	f	class:GraphView
+keyPressEvent	showgraph/GraphView/node_item.cpp	/^void NodeItem::keyPressEvent(QKeyEvent *event)$/;"	f	class:NodeItem
+keywordFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat keywordFormat;$/;"	m	class:Highlighter
+langFile	gui/langtable.cpp	/^	const char* langFile;$/;"	m	struct:__anon1	file:
+langName	gui/langtable.cpp	/^	const char* langName;$/;"	m	struct:__anon1	file:
+langTable	gui/langtable.cpp	/^static const langTableType langTable[]=$/;"	v	file:
+langTableType	gui/langtable.cpp	/^}langTableType;$/;"	t	typeref:struct:__anon1	file:
+langstyle	gui/themes.cpp	/^}langstyle;$/;"	t	typeref:struct:__anon3	file:
+langtable	gui/langtable.h	/^class langtable$/;"	c
+langtypes	gui/fileviewer.h	/^enum langtypes$/;"	g
+last	showgraph/Graph/marker.h	/^    MarkerValue last;$/;"	m	class:MarkerManager
+last	showgraph/Graph/num.h	/^    NumValue last;$/;"	m	class:NumManager
+last	showgraph/GraphView/graph_view.cpp	/^NavEvent *GraphViewHistory::last()$/;"	f	class:GraphViewHistory
+layoutNextStep	showgraph/Layout/layout.cpp	/^void AuxGraph::layoutNextStep()$/;"	f	class:AuxGraph
+layoutPostProcess	showgraph/GraphView/graph_view.cpp	/^void GGraph::layoutPostProcess()$/;"	f	class:GGraph
+layoutPostProcess	showgraph/Layout/layout.cpp	/^void AuxGraph::layoutPostProcess()$/;"	f	class:AuxGraph
+layout_in_process	showgraph/Layout/aux_graph.h	/^    bool layout_in_process;$/;"	m	class:AuxGraph
+left	showgraph/Layout/node_group.h	/^    inline qreal left() const$/;"	f	class:NodeGroup
+level	showgraph/Layout/aux_node.h	/^    inline Level *level() const$/;"	f	class:AuxNode
+level_rank	showgraph/Layout/aux_graph.h	/^    Rank level_rank;$/;"	m	class:Level
+levels	showgraph/Layout/aux_graph.h	/^    QVector< Level*> levels;$/;"	m	class:AuxGraph
+lexstyle	gui/themes.cpp	/^}lexstyle;$/;"	t	typeref:struct:__anon2	file:
+lexstylesize	gui/themes.cpp	/^	int lexstylesize;$/;"	m	struct:__anon3	file:
+lexstyletable	gui/themes.cpp	/^	const lexstyle *lexstyletable;$/;"	m	struct:__anon3	file:
+lineNumberArea	gui/obsolete/CodeEditor.h	/^     QWidget *lineNumberArea;$/;"	m	class:CodeEditor
+lineNumberAreaPaintEvent	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)$/;"	f	class:CodeEditor
+lineNumberAreaWidth	gui/obsolete/CodeEditor.cpp	/^ int CodeEditor::lineNumberAreaWidth()$/;"	f	class:CodeEditor
+line_color_button	showgraph/GraphView/style_edit.h	/^    ColorButton *line_color_button;$/;"	m	class:StyleEdit
+line_color_label	showgraph/GraphView/style_edit.h	/^    QLabel *line_color_label;$/;"	m	class:StyleEdit
+line_num	makedb/csdbparser.h	/^long int line_num;$/;"	m	class:symdata_pack
+line_num_str	makedb/csdbparser.cpp	/^std::string symdata_pack::line_num_str(void)$/;"	f	class:symdata_pack
+line_style_combo	showgraph/GraphView/style_edit.h	/^    QComboBox *line_style_combo;$/;"	m	class:StyleEdit
+line_style_label	showgraph/GraphView/style_edit.h	/^    QLabel *line_style_label;$/;"	m	class:StyleEdit
+line_text	makedb/csdbparser.h	/^std::string line_text;$/;"	m	class:symdata_pack
+line_text_blob	makedb/csdbparser.cpp	/^std::string symdata_pack::line_text_blob(void)$/;"	f	class:symdata_pack
+line_text_escaped	makedb/csdbparser.cpp	/^std::string symdata_pack::line_text_escaped(void)$/;"	f	class:symdata_pack
+line_text_replacetab	makedb/csdbparser.cpp	/^std::string symdata_pack::line_text_replacetab(void)$/;"	f	class:symdata_pack
+line_width_label	showgraph/GraphView/style_edit.h	/^    QLabel *line_width_label;$/;"	m	class:StyleEdit
+line_width_spin	showgraph/GraphView/style_edit.h	/^    QDoubleSpinBox *line_width_spin;$/;"	m	class:StyleEdit
+linenum	gui/fileviewer.h	/^	QString linenum;$/;"	m	class:filedata
+linenum	querylib/sqlquery.h	/^	tStr linenum;$/;"	m	class:sqlqueryresult
+linetext	querylib/sqlquery.h	/^	tStr linetext;$/;"	m	class:sqlqueryresult
+listItemClicked	gui/listhandler.cpp	/^void listhandler::listItemClicked(QTreeWidgetItem * current, QTreeWidgetItem * previous)$/;"	f	class:listhandler
+listhandler	gui/listhandler.cpp	/^listhandler::listhandler(mainwindow* pmw)$/;"	f	class:listhandler
+listhandler	gui/listhandler.h	/^class listhandler : public QObject$/;"	c
+literalFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat literalFormat;$/;"	m	class:Highlighter
+longName	showgraph/Utils/conf.h	/^    inline QString longName() const$/;"	f	class:Option
+longOption	showgraph/Utils/conf.h	/^    inline Option* longOption( QString name)$/;"	f	class:Conf
+long_name	showgraph/Utils/conf.h	/^    QString long_name;$/;"	m	class:Option
+long_opts	showgraph/Utils/conf.h	/^    QHash< QString, Option *> long_opts;$/;"	m	class:Conf
+m_DBtimestamp	gui/fileviewer.h	/^QDateTime m_DBtimestamp;$/;"	m	class:fileviewer
+m_HighlightedLineNumber	gui/obsolete/CodeEditor.h	/^     int m_HighlightedLineNumber;$/;"	m	class:CodeEditor
+m_app	gui/mainwindow.h	/^QApplication *m_app;$/;"	m	class:mainwindow
+m_autocompBusy	gui/searchhandler.h	/^bool m_autocompBusy;$/;"	m	class:searchhandler
+m_autocompFutureWatcher	gui/searchhandler.h	/^QFutureWatcher<QStringList> m_autocompFutureWatcher;$/;"	m	class:searchhandler
+m_autocompSrchTerm	gui/searchhandler.h	/^QString m_autocompSrchTerm;$/;"	m	class:searchhandler
+m_autocompstmt	querylib/sqlquery.h	/^	tempstmt m_autocompstmt;$/;"	m	class:sqlquery
+m_base_path	makedb/csdbheader.h	/^tStr m_base_path;$/;"	m	class:csdbheader
+m_base_path	makedb/csdbparser.h	/^std::string m_base_path;$/;"	m	class:csdbparser
+m_basepath	querylib/sqlquery.h	/^	tStr m_basepath;$/;"	m	class:sqlquery
+m_buf	makedb/cs2sq.h	/^char* m_buf;$/;"	m	class:cs2sq
+m_buf	makedb/csdbparser.h	/^char *m_buf;$/;"	m	class:csdbparser
+m_buf	querylib/small_lib.h	/^	char m_buf[20];$/;"	m	class:idxcounter
+m_buffer	querylib/small_lib.h	/^char* m_buffer;$/;"	m	class:tempbuf
+m_bufsize	makedb/csdbparser.h	/^long int m_bufsize;$/;"	m	class:csdbparser
+m_calling_func	makedb/cs2sq.h	/^stStrID m_calling_func;$/;"	m	class:cs2sq
+m_calling_func	makedb/csdbparser.h	/^std::string m_calling_func;$/;"	m	class:csdbparser
+m_calling_macro	makedb/cs2sq.h	/^stStrID m_calling_macro;$/;"	m	class:cs2sq
+m_calling_macro	makedb/csdbparser.h	/^std::string m_calling_macro;$/;"	m	class:csdbparser
+m_callstmt	makedb/cs2sq.h	/^sqlite3_stmt* m_callstmt;$/;"	m	class:cs2sq
+m_checkBoxAutoComplete	gui/searchhandler.h	/^QCheckBox *m_checkBoxAutoComplete;$/;"	m	class:searchhandler
+m_checkBoxExactMatch	gui/searchhandler.h	/^QCheckBox *m_checkBoxExactMatch;$/;"	m	class:searchhandler
+m_checkBoxFilter	gui/searchhandler.h	/^QCheckBox *m_checkBoxFilter;$/;"	m	class:searchhandler
+m_checkBoxSymbolOnly	gui/fileviewer.h	/^QCheckBox   *m_checkBoxSymbolOnly;$/;"	m	class:fileviewer
+m_comboBoxDB	gui/searchhandler.h	/^QComboBox *m_comboBoxDB;$/;"	m	class:searchhandler
+m_comboBoxFilter	gui/searchhandler.h	/^QComboBox *m_comboBoxFilter;$/;"	m	class:searchhandler
+m_comboBoxQueryType	gui/searchhandler.h	/^QComboBox *m_comboBoxQueryType;$/;"	m	class:searchhandler
+m_comboBoxSearch	gui/searchhandler.h	/^QComboBox *m_comboBoxSearch;$/;"	m	class:searchhandler
+m_completer	gui/searchhandler.h	/^QCompleter *m_completer;$/;"	m	class:searchhandler
+m_csdbp	makedb/cs2sq.h	/^csdbparser m_csdbp;$/;"	m	class:cs2sq
+m_csdbpLastErr	makedb/cs2sq.h	/^csdbparser::enResult m_csdbpLastErr;$/;"	m	class:cs2sq
+m_csdbver	makedb/csdbheader.h	/^long int m_csdbver;$/;"	m	class:csdbheader
+m_ctr	querylib/small_lib.h	/^	long unsigned int m_ctr;$/;"	m	class:idxcounter
+m_currentLanguage	gui/mainwindow.h	/^QString m_currentLanguage;$/;"	m	class:mainwindow
+m_current_srcfile	makedb/csdbparser.h	/^std::string m_current_srcfile;$/;"	m	class:csdbparser
+m_currentlang	gui/fileviewer.h	/^int m_currentlang;$/;"	m	class:fileviewer
+m_db	makedb/sqlbase.h	/^sqlite3 *m_db;$/;"	m	class:sqlbase
+m_db	querylib/sqlquery.h	/^	sqlite3 *m_db;$/;"	m	class:sqlquery
+m_debug	makedb/csdbparser.h	/^bool m_debug;$/;"	m	class:csdbparser
+m_debug	makedb/sqlbase.h	/^bool m_debug;$/;"	m	class:sqlbase
+m_dot	gui/graphdialog.h	/^QString m_dot;$/;"	m	class:cqDialogGraph
+m_externalEditorPath	gui/fileviewer.h	/^QString m_externalEditorPath;$/;"	m	class:fileviewer
+m_fileDataList	gui/fileviewer.h	/^QVector<filedata> m_fileDataList;$/;"	m	class:fileviewer
+m_filesstmt	makedb/cs2sq.h	/^sqlite3_stmt* m_filesstmt;$/;"	m	class:cs2sq
+m_fileviewer	gui/mainwindow.h	/^fileviewer* m_fileviewer;$/;"	m	class:mainwindow
+m_fontlist	gui/fileviewer.h	/^QStringList m_fontlist;$/;"	m	class:fileviewer
+m_fontsize	gui/fileviewer.h	/^int m_fontsize;$/;"	m	class:fileviewer
+m_fonttemp	gui/fileviewer.h	/^QString m_fonttemp;$/;"	m	class:fileviewer
+m_fontwidthtemp	gui/fileviewer.h	/^int m_fontwidthtemp;$/;"	m	class:fileviewer
+m_fp	makedb/csdbparser.h	/^FILE *m_fp;$/;"	m	class:csdbparser
+m_fp	querylib/small_lib.h	/^FILE* m_fp;$/;"	m	class:smartFILE
+m_fv	gui/fileviewsettingsdialog.h	/^fileviewer* m_fv;$/;"	m	class:cqDialogFileViewSettings
+m_graphdesc	gui/searchhandler.h	/^QString m_graphdesc;$/;"	m	class:searchhandler
+m_grepExactMatch	gui/searchhandler.cpp	/^bool searchhandler::m_grepExactMatch = false;$/;"	m	class:searchhandler	file:
+m_grepExactMatch	gui/searchhandler.h	/^static bool m_grepExactMatch;$/;"	m	class:searchhandler
+m_grepRegExp	gui/searchhandler.cpp	/^QRegExp* searchhandler::m_grepRegExp = NULL;$/;"	m	class:searchhandler	file:
+m_grepRegExp	gui/searchhandler.h	/^static QRegExp* m_grepRegExp;$/;"	m	class:searchhandler
+m_header	makedb/csdbheader.h	/^tStr m_header;$/;"	m	class:csdbheader
+m_img	gui/graphdialog.h	/^QImage m_img;$/;"	m	class:cqDialogGraph
+m_insertinheritstmt	makedb/ctagread.h	/^sqlite3_stmt* m_insertinheritstmt;$/;"	m	class:ctagread
+m_insertstmt	makedb/ctagread.h	/^sqlite3_stmt* m_insertstmt;$/;"	m	class:ctagread
+m_intAddlRulesMode	gui/obsolete/highlighter.h	/^     int m_intAddlRulesMode;$/;"	m	class:Highlighter
+m_intLanguage	gui/obsolete/highlighter.h	/^     int m_intLanguage;$/;"	m	class:Highlighter
+m_itemlist	gui/listhandler.h	/^QList<QTreeWidgetItem*> m_itemlist;$/;"	m	class:listhandler
+m_iter	gui/fileviewer.h	/^QVector<filedata>::iterator m_iter;$/;"	m	class:fileviewer
+m_iter	gui/searchhandler.h	/^QVector<searchitem>::iterator m_iter;$/;"	m	class:searchhandler
+m_labelFilePath	gui/fileviewer.h	/^QLabel *m_labelFilePath;$/;"	m	class:fileviewer
+m_lexer	gui/fileviewer.h	/^QsciLexer* m_lexer;$/;"	m	class:fileviewer
+m_linesstmt	makedb/cs2sq.h	/^sqlite3_stmt* m_linesstmt;$/;"	m	class:cs2sq
+m_listhandler	gui/mainwindow.h	/^listhandler* m_listhandler;$/;"	m	class:mainwindow
+m_markerhandle	gui/fileviewer.h	/^int m_markerhandle;$/;"	m	class:fileviewer
+m_noclick	gui/listhandler.h	/^bool m_noclick;$/;"	m	class:listhandler
+m_param_list	makedb/csdbheader.h	/^tVecStr m_param_list;$/;"	m	class:csdbheader
+m_pushButtonClipSearch	gui/searchhandler.h	/^QPushButton *m_pushButtonClipSearch;$/;"	m	class:searchhandler
+m_pushButtonDown	gui/listhandler.h	/^QPushButton *m_pushButtonDown;$/;"	m	class:listhandler
+m_pushButtonGoToLine	gui/fileviewer.h	/^QPushButton *m_pushButtonGoToLine;$/;"	m	class:fileviewer
+m_pushButtonGraph	gui/searchhandler.h	/^QPushButton *m_pushButtonGraph;$/;"	m	class:searchhandler
+m_pushButtonNext	gui/fileviewer.h	/^QPushButton *m_pushButtonNext;$/;"	m	class:fileviewer
+m_pushButtonOpenDB	gui/searchhandler.h	/^QPushButton *m_pushButtonOpenDB;$/;"	m	class:searchhandler
+m_pushButtonOpenInEditor	gui/fileviewer.h	/^QPushButton *m_pushButtonOpenInEditor;$/;"	m	class:fileviewer
+m_pushButtonPaste	gui/fileviewer.h	/^QPushButton *m_pushButtonPaste;$/;"	m	class:fileviewer
+m_pushButtonPrev	gui/fileviewer.h	/^QPushButton *m_pushButtonPrev;$/;"	m	class:fileviewer
+m_pushButtonSearch	gui/searchhandler.h	/^QPushButton *m_pushButtonSearch;$/;"	m	class:searchhandler
+m_pushButtonSearchNext	gui/searchhandler.h	/^QPushButton *m_pushButtonSearchNext;$/;"	m	class:searchhandler
+m_pushButtonSearchPrev	gui/searchhandler.h	/^QPushButton *m_pushButtonSearchPrev;$/;"	m	class:searchhandler
+m_pushButtonTextEnlarge	gui/fileviewer.h	/^QPushButton *m_pushButtonTextEnlarge;$/;"	m	class:fileviewer
+m_pushButtonTextShrink	gui/fileviewer.h	/^QPushButton *m_pushButtonTextShrink;$/;"	m	class:fileviewer
+m_pushButtonUp	gui/listhandler.h	/^QPushButton *m_pushButtonUp;$/;"	m	class:listhandler
+m_readclassstmt	makedb/ctagread.h	/^sqlite3_stmt* m_readclassstmt;$/;"	m	class:ctagread
+m_readsymfstmt	makedb/ctagread.h	/^sqlite3_stmt* m_readsymfstmt;$/;"	m	class:ctagread
+m_readsymstmt	makedb/ctagread.h	/^sqlite3_stmt* m_readsymstmt;$/;"	m	class:ctagread
+m_scaleFactor	gui/graphdialog.h	/^double m_scaleFactor;$/;"	m	class:cqDialogGraph
+m_searchMemoryList	gui/searchhandler.h	/^QVector<searchitem> m_searchMemoryList;$/;"	m	class:searchhandler
+m_searchhandler	gui/mainwindow.h	/^searchhandler* m_searchhandler;$/;"	m	class:mainwindow
+m_searchstmt	querylib/sqlquery.h	/^	tempstmt m_searchstmt;$/;"	m	class:sqlquery
+m_size	querylib/small_lib.h	/^unsigned int m_size;$/;"	m	class:tempbuf
+m_sqlist	gui/listhandler.h	/^sqlqueryresultlist m_sqlist;$/;"	m	class:listhandler
+m_srchStrLstModel	gui/searchhandler.h	/^QStringListModel m_srchStrLstModel;$/;"	m	class:searchhandler
+m_state	makedb/csdbparser.h	/^enState m_state;$/;"	m	class:csdbparser
+m_stmt	querylib/sqlquery.h	/^sqlite3_stmt *m_stmt;$/;"	m	class:tempstmt
+m_symstmt	makedb/cs2sq.h	/^sqlite3_stmt* m_symstmt;$/;"	m	class:cs2sq
+m_tabwidthvalidator	gui/fileviewsettingsdialog.h	/^QIntValidator m_tabwidthvalidator;$/;"	m	class:cqDialogFileViewSettings
+m_textEditSource	gui/fileviewer.h	/^QsciScintilla *m_textEditSource;$/;"	m	class:fileviewer
+m_textEditSourceFont	gui/fileviewer.h	/^QFont m_textEditSourceFont;$/;"	m	class:fileviewer
+m_theme	gui/fileviewer.h	/^QString m_theme;$/;"	m	class:fileviewer
+m_themelast	gui/fileviewer.h	/^QString m_themelast;$/;"	m	class:fileviewer
+m_themetemp	gui/fileviewer.h	/^QString m_themetemp;$/;"	m	class:fileviewer
+m_timestampMismatchWarned	gui/fileviewer.h	/^bool m_timestampMismatchWarned;$/;"	m	class:fileviewer
+m_trailer_start	makedb/csdbheader.h	/^long int m_trailer_start;$/;"	m	class:csdbheader
+m_trailer_start	makedb/csdbparser.h	/^long int m_trailer_start;$/;"	m	class:csdbparser
+m_translator	gui/mainwindow.h	/^QTranslator m_translator;$/;"	m	class:mainwindow
+m_treeWidgetSearchResults	gui/listhandler.h	/^QTreeWidget *m_treeWidgetSearchResults;$/;"	m	class:listhandler
+m_typeOfGraph	gui/searchhandler.h	/^int m_typeOfGraph; \/\/ 1 = Function Call, 2 = Class Inheritance$/;"	m	class:searchhandler
+m_writedeststmt	makedb/ctagread.h	/^sqlite3_stmt* m_writedeststmt;$/;"	m	class:ctagread
+main	cli/main_cli.cpp	/^int main(int argc, char *argv[])$/;"	f
+main	gui/main_gui.cpp	/^int main(int argc, char *argv[])$/;"	f
+main	makedb/main.cpp	/^int main(int argc, char *argv[])$/;"	f
+mainwindow	gui/mainwindow.cpp	/^mainwindow::mainwindow(QMainWindow *parent, QApplication *app)$/;"	f	class:mainwindow
+mainwindow	gui/mainwindow.h	/^class mainwindow : public QMainWindow$/;"	c
+mark	showgraph/Graph/marker.h	/^inline bool Marked::mark( Marker marker)$/;"	f	class:Marked
+markReachableDown	showgraph/Layout/layout.cpp	/^AuxGraph::markReachableDown( AuxNode *n,$/;"	f	class:AuxGraph
+markers	showgraph/Graph/marker.h	/^    MarkerValue markers[ MAX_GRAPH_MARKERS];$/;"	m	class:Marked
+markers	showgraph/Graph/marker.h	/^    MarkerValue markers[ MAX_GRAPH_MARKERS];$/;"	m	class:MarkerManager
+maxRank	showgraph/Layout/aux_graph.h	/^    inline GraphNum maxRank() const$/;"	f	class:AuxGraph
+max_rank	showgraph/Layout/aux_graph.h	/^    GraphNum max_rank;$/;"	m	class:AuxGraph
+merge	showgraph/Layout/node_group.cpp	/^void NodeGroup::merge( NodeGroup *grp)$/;"	f	class:NodeGroup
+message	showgraph/GraphView/gview_iface.h	/^    inline QString message()$/;"	f	class:GGraphError
+mode	showgraph/GraphView/edge_item.h	/^    inline EdgeMode mode() const$/;"	f	class:EdgeItem
+modelX	showgraph/Layout/aux_node.h	/^    inline double modelX() const$/;"	f	class:AuxNode
+modelY	showgraph/Layout/aux_node.h	/^    inline double modelY() const$/;"	f	class:AuxNode
+mouseDoubleClickEvent	showgraph/GraphView/edge_item.cpp	/^void EdgeItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *ev)$/;"	f	class:EdgeItem
+mouseDoubleClickEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::mouseDoubleClickEvent(QMouseEvent *ev)$/;"	f	class:GraphView
+mouseDoubleClickEvent	showgraph/GraphView/node_item.cpp	/^void NodeItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)$/;"	f	class:NodeItem
+mouseMoveEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::mouseMoveEvent(QMouseEvent *ev)$/;"	f	class:GraphView
+mousePressEvent	showgraph/GraphView/edge_item.cpp	/^void EdgeItem::mousePressEvent(QGraphicsSceneMouseEvent *event)$/;"	f	class:EdgeItem
+mousePressEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::mousePressEvent(QMouseEvent *ev)$/;"	f	class:GraphView
+mousePressEvent	showgraph/GraphView/node_item.cpp	/^void NodeItem::mousePressEvent( QGraphicsSceneMouseEvent *event)$/;"	f	class:NodeItem
+mouseReleaseEvent	showgraph/GraphView/edge_item.cpp	/^void EdgeItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *ev)$/;"	f	class:EdgeItem
+mouseReleaseEvent	showgraph/GraphView/graph_view.cpp	/^GraphView::mouseReleaseEvent( QMouseEvent *ev)$/;"	f	class:GraphView
+mouseReleaseEvent	showgraph/GraphView/node_item.cpp	/^void NodeItem::mouseReleaseEvent( QGraphicsSceneMouseEvent *event)$/;"	f	class:NodeItem
+msg_priv	showgraph/GraphView/gview_iface.h	/^    QString msg_priv;$/;"	m	class:GGraphError
+multiLineCommentFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat multiLineCommentFormat;$/;"	m	class:Highlighter
+mw	gui/fileviewer.h	/^mainwindow *mw;$/;"	m	class:fileviewer
+mw	gui/listhandler.h	/^mainwindow *mw;$/;"	m	class:listhandler
+mw	gui/searchhandler.h	/^mainwindow *mw;$/;"	m	class:searchhandler
+my_pos	showgraph/Utils/mem_entry.h	/^        ChunkPos my_pos;$/;"	m	class:MemImpl::Entry
+name	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::name() const$/;"	f	class:CodeEditorWidgetPlugin
+name	showgraph/GraphView/gstyle.h	/^inline QString GStyle::name() const$/;"	f	class:GStyle
+name_combo	showgraph/GraphView/style_edit.h	/^    QComboBox *name_combo;$/;"	m	class:StyleEdit
+name_label	showgraph/GraphView/style_edit.h	/^    QLabel *name_label;$/;"	m	class:StyleEdit
+name_priv	showgraph/GraphView/gstyle.h	/^    QString name_priv;$/;"	m	class:GStyle
+navNext	showgraph/GraphView/graph_view.cpp	/^void GraphView::navNext()$/;"	f	class:GraphView
+navPrev	showgraph/GraphView/graph_view.cpp	/^void GraphView::navPrev()$/;"	f	class:GraphView
+newEdge	showgraph/Graph/agraph.h	/^    AEdge* newEdge( ANode* pred, ANode* succ)$/;"	f	class:AGraph
+newEdge	showgraph/Graph/graph_inline.h	/^Graph::newEdge( Node * pred, Node * succ)$/;"	f	class:Graph
+newEdge	showgraph/Graph/graph_inline.h	/^Graph::newEdge( Node * pred, Node * succ, QDomElement e)$/;"	f	class:Graph
+newEdge	showgraph/GraphView/graph_view.cpp	/^GGraph::newEdge( GNode* pred, GNode* succ)$/;"	f	class:GGraph
+newEdge	showgraph/GraphView/graph_view.cpp	/^GGraph::newEdge( GNode* pred, GNode* succ, QDomElement e)$/;"	f	class:GGraph
+newEdge	showgraph/GraphView/graph_view.h	/^    AuxEdge* newEdge( AuxNode * pred, AuxNode *succ)$/;"	f	class:GGraph
+newEdge	showgraph/GraphView/graph_view.h	/^    AuxEdge* newEdge( AuxNode * pred, AuxNode *succ, QDomElement e)$/;"	f	class:GGraph
+newEdgeImpl	showgraph/Graph/graph_inline.h	/^Graph::newEdgeImpl( Node * pred, Node * succ)$/;"	f	class:Graph
+newMarker	showgraph/Graph/marker.h	/^inline Marker MarkerManager::newMarker()$/;"	f	class:MarkerManager
+newNode	showgraph/Graph/agraph.h	/^    ANode* newNode()$/;"	f	class:AGraph
+newNode	showgraph/Graph/graph_inline.h	/^Graph::newNode( QDomElement e)$/;"	f	class:Graph
+newNode	showgraph/Graph/graph_inline.h	/^Graph::newNode()$/;"	f	class:Graph
+newNode	showgraph/GraphView/graph_view.cpp	/^GGraph::newNode( QDomElement e)$/;"	f	class:GGraph
+newNode	showgraph/GraphView/graph_view.cpp	/^GGraph::newNode()$/;"	f	class:GGraph
+newNodeImpl	showgraph/Graph/graph_inline.h	/^Graph::newNodeImpl( GraphUid id)$/;"	f	class:Graph
+newNum	showgraph/Graph/num.h	/^inline Numeration NumManager::newNum()$/;"	f	class:NumManager
+newSearchText	gui/searchhandler.cpp	/^void searchhandler::newSearchText()$/;"	f	class:searchhandler
+newSearchTextSymbolOnly	gui/searchhandler.cpp	/^void searchhandler::newSearchTextSymbolOnly()$/;"	f	class:searchhandler
+new_style	showgraph/GraphView/graph_view.h	/^        GStyle *new_style;$/;"	m	struct:GraphView::StyleEditInfo
+next	makedb/optlist.h	/^    struct option_t *next;$/;"	m	struct:option_t	typeref:struct:option_t::option_t
+next	showgraph/GraphView/graph_view.cpp	/^NavEvent *GraphViewHistory::next()$/;"	f	class:GraphViewHistory
+next	showgraph/Utils/list.h	/^    inline Item *next( ListId list) const$/;"	f	class:MListIface
+next	showgraph/Utils/list.h	/^    inline Item *next() const$/;"	f	class:MListIface
+next	showgraph/Utils/list.h	/^    inline Item *next() const$/;"	f	class:SListIface
+next	showgraph/Utils/list.h	/^    inline ListItem<Data> *next() const$/;"	f	class:ListItem
+next	showgraph/Utils/list.h	/^    inline MListItem< 1> *next() const$/;"	f	class:MListItem
+next	showgraph/Utils/list.h	/^    inline MListItem< dim> *next( ListId list) const$/;"	f	class:MListItem
+nextEdge	showgraph/Graph/agraph.h	/^    inline AEdge* nextEdge()$/;"	f	class:AEdge
+nextEdge	showgraph/Graph/edge_inline.h	/^inline Edge* Edge::nextEdge()$/;"	f	class:Edge
+nextEdge	showgraph/Graph/node_inline.h	/^inline void PredIterImpl::nextEdge()$/;"	f	class:PredIterImpl
+nextEdge	showgraph/Graph/node_inline.h	/^inline void SuccIterImpl::nextEdge()$/;"	f	class:SuccIterImpl
+nextEdge	showgraph/Graph/node_inline.h	/^inline void UnDirIterImpl::nextEdge()$/;"	f	class:UnDirIterImpl
+nextEdge	showgraph/GraphView/edge_item.h	/^    inline GEdge* nextEdge()$/;"	f	class:GEdge
+nextEdge	showgraph/Layout/aux_edge.h	/^    inline AuxEdge* nextEdge()$/;"	f	class:AuxEdge
+nextEdgeInDir	showgraph/Graph/agraph.h	/^    inline AEdge* nextEdgeInDir( GraphDir dir)$/;"	f	class:AEdge
+nextEdgeInDir	showgraph/Graph/edge_inline.h	/^inline Edge* Edge::nextEdgeInDir( GraphDir dir)$/;"	f	class:Edge
+nextEdgeInDir	showgraph/GraphView/edge_item.h	/^    inline GEdge* nextEdgeInDir( GraphDir dir)$/;"	f	class:GEdge
+nextEdgeInDir	showgraph/Layout/aux_edge.h	/^    inline AuxEdge* nextEdgeInDir( GraphDir dir)$/;"	f	class:AuxEdge
+nextFree	showgraph/Utils/mem_entry.h	/^    Entry< Data>::nextFree() const$/;"	f	class:MemImpl::Entry
+nextNode	showgraph/Graph/agraph.h	/^    inline ANode* nextNode()$/;"	f	class:ANode
+nextNode	showgraph/Graph/node_inline.h	/^inline Node* Node::nextNode()$/;"	f	class:Node
+nextNode	showgraph/GraphView/node_item.h	/^    inline GNode* nextNode()$/;"	f	class:GNode
+nextNode	showgraph/Layout/aux_node.h	/^    inline AuxNode* nextNode()$/;"	f	class:AuxNode
+nextPred	showgraph/Graph/agraph.h	/^    inline AEdge* nextPred()$/;"	f	class:AEdge
+nextPred	showgraph/Graph/edge_inline.h	/^inline Edge* Edge::nextPred()$/;"	f	class:Edge
+nextPred	showgraph/GraphView/edge_item.h	/^    inline GEdge* nextPred()$/;"	f	class:GEdge
+nextPred	showgraph/Layout/aux_edge.h	/^    inline AuxEdge* nextPred()$/;"	f	class:AuxEdge
+nextSucc	showgraph/Graph/agraph.h	/^    inline AEdge* nextSucc()$/;"	f	class:AEdge
+nextSucc	showgraph/Graph/edge_inline.h	/^inline Edge* Edge::nextSucc()$/;"	f	class:Edge
+nextSucc	showgraph/GraphView/edge_item.h	/^    inline GEdge* nextSucc()$/;"	f	class:GEdge
+nextSucc	showgraph/Layout/aux_edge.h	/^    inline AuxEdge* nextSucc()$/;"	f	class:AuxEdge
+nextValue	showgraph/Graph/marker.h	/^MarkerManager::nextValue()$/;"	f	class:MarkerManager
+nextValue	showgraph/Graph/num.h	/^inline NumValue NumManager::nextValue()$/;"	f	class:NumManager
+next_free_pos	showgraph/Utils/mem_entry.h	/^        ChunkPos next_free_pos;$/;"	m	class:MemImpl::Entry
+node	showgraph/Graph/agraph.h	/^    inline ANode *node( GraphDir dir) const$/;"	f	class:AEdge
+node	showgraph/Graph/edge_inline.h	/^inline Node *Edge::node( GraphDir dir) const$/;"	f	class:Edge
+node	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::node() const$/;"	f	class:EdgeIterIface
+node	showgraph/Graph/node_inline.h	/^inline Node * PredIterImpl::node() const$/;"	f	class:PredIterImpl
+node	showgraph/Graph/node_inline.h	/^inline Node * SuccIterImpl::node() const$/;"	f	class:SuccIterImpl
+node	showgraph/Graph/node_inline.h	/^inline Node * UnDirIterImpl::node() const$/;"	f	class:UnDirIterImpl
+node	showgraph/GraphView/edge_item.cpp	/^GEdge::node( GraphDir dir) const $/;"	f	class:GEdge
+node	showgraph/GraphView/graph_view.h	/^        GNode *node;$/;"	m	union:NavEvent::NavEventData
+node	showgraph/GraphView/graph_view.h	/^        GNode* node;$/;"	m	struct:GraphView::StyleEditInfo
+node	showgraph/GraphView/graph_view.h	/^    inline GNode *node() const$/;"	f	class:NavEvent
+node	showgraph/GraphView/navigation.h	/^GNode* NodeNav::node() const$/;"	f	class:NodeNav
+node	showgraph/GraphView/node_item.h	/^    inline GNode *node() const$/;"	f	class:NodeItem
+node	showgraph/Layout/aux_edge.h	/^    inline AuxNode *node( GraphDir dir) const$/;"	f	class:AuxEdge
+node	showgraph/Layout/aux_graph.h	/^        AuxNode *node; \/\/ Node in consideration$/;"	m	struct:AuxGraph::SimpleDfsStepInfo
+node	showgraph/Layout/layout.cpp	/^    AuxNode *node; \/** Node in consideration *\/$/;"	m	struct:DfsStepInfo	file:
+nodeCount	showgraph/Graph/graph_inline.h	/^inline GraphNum Graph::nodeCount() const$/;"	f	class:Graph
+nodeDown	showgraph/GraphView/visible_edge.cpp	/^VEdge::nodeDown() const$/;"	f	class:VEdge
+nodeInDepth	showgraph/Layout/layout.cpp	/^    AuxNode *nodeInDepth()$/;"	f	struct:DfsStepInfo
+nodeInFocus	showgraph/GraphView/graph_view.h	/^    inline GNode* nodeInFocus() const$/;"	f	class:GGraph
+nodeItemMenu	showgraph/GraphView/graph_view.h	/^    QMenu *nodeItemMenu;$/;"	m	class:GraphView
+nodeLeft	showgraph/GraphView/visible_edge.cpp	/^VEdge::nodeLeft() const$/;"	f	class:VEdge
+nodeMenu	showgraph/GraphView/graph_view.h	/^    inline QMenu *nodeMenu() const$/;"	f	class:GraphView
+nodeNavigationSector	showgraph/GraphView/graph_view.h	/^    inline NavSector nodeNavigationSector() const$/;"	f	class:GGraph
+nodePool	showgraph/Graph/graph_inline.h	/^inline Pool *Graph::nodePool() const$/;"	f	class:Graph
+nodeRight	showgraph/GraphView/visible_edge.cpp	/^VEdge::nodeRight() const$/;"	f	class:VEdge
+nodeShape2Str	showgraph/GraphView/gstyle.h	/^nodeShape2Str( NodeShape shape)$/;"	f
+nodeTextIsShown	showgraph/GraphView/graph_view.h	/^    Marker nodeTextIsShown;$/;"	m	class:GGraph
+nodeUp	showgraph/GraphView/visible_edge.cpp	/^VEdge::nodeUp() const$/;"	f	class:VEdge
+node_animation_timer	showgraph/GraphView/graph_view.h	/^    int node_animation_timer;$/;"	m	class:GraphView
+node_in_focus	showgraph/GraphView/graph_view.h	/^    NodeNav node_in_focus;\/\/ Node in focus + navigation sector$/;"	m	class:GGraph
+node_list	showgraph/Layout/aux_graph.h	/^    QList< AuxNode*> node_list;$/;"	m	class:Level
+node_list	showgraph/Layout/node_group.h	/^    QList< AuxNode *> node_list;$/;"	m	class:NodeGroup
+node_next_id	showgraph/Graph/graph.h	/^    GraphUid node_next_id;$/;"	m	class:Graph
+node_num	showgraph/Graph/graph.h	/^    GraphNum node_num;$/;"	m	class:Graph
+node_p	showgraph/GraphView/node_item.h	/^    GNode *node_p;$/;"	m	class:NodeItem
+node_pool	showgraph/Graph/graph.h	/^    Pool *node_pool;$/;"	m	class:Graph
+node_priv	showgraph/GraphView/navigation.h	/^    GNode *node_priv;$/;"	m	class:NodeNav
+node_type	showgraph/Layout/aux_node.h	/^    AuxNodeType node_type;$/;"	m	class:AuxNode
+nodes	showgraph/Graph/edge.h	/^    Node *nodes[ GRAPH_DIRS_NUM]; \/\/Adjacent nodes$/;"	m	class:Edge
+nodes	showgraph/Layout/aux_graph.h	/^    inline QList< AuxNode*> nodes() const$/;"	f	class:Level
+nodes	showgraph/Layout/node_group.h	/^    QList<AuxNode *> nodes() const$/;"	f	class:NodeGroup
+numItems	showgraph/GraphView/gstyle.h	/^inline GraphNum GStyle::numItems()$/;"	f	class:GStyle
+num_items	showgraph/GraphView/gstyle.h	/^    GraphNum num_items;$/;"	m	class:GStyle
+number	showgraph/Graph/num.h	/^Numbered::number( Numeration num)$/;"	f	class:Numbered
+numbers	showgraph/Graph/num.h	/^    GraphNum numbers[ MAX_NUMERATIONS];$/;"	m	class:Numbered
+nums	showgraph/Graph/num.h	/^    NumValue nums[ MAX_NUMERATIONS];$/;"	m	class:NumManager
+nums	showgraph/Graph/num.h	/^    NumValue nums[ MAX_NUMERATIONS];$/;"	m	class:Numbered
+ok	showgraph/GraphView/style_edit.h	/^    QPushButton *ok;$/;"	m	class:StyleEdit
+old_style	showgraph/GraphView/graph_view.h	/^        GStyle *old_style;$/;"	m	struct:GraphView::StyleEditInfo
+opacity	showgraph/GraphView/node_item.h	/^    qreal opacity;$/;"	m	class:NodeItem
+opacityLevel	showgraph/GraphView/node_item.h	/^    inline qreal opacityLevel() const$/;"	f	class:NodeItem
+open_csdb	makedb/cs2sq.cpp	/^csdbparser::enResult cs2sq::open_csdb(const char* csdbfn)$/;"	f	class:cs2sq
+open_db	makedb/cs2sq.cpp	/^cs2sq::enResult cs2sq::open_db(const char* sqldb)$/;"	f	class:cs2sq
+open_dbfile	querylib/sqlquery.cpp	/^sqlquery::en_filereadstatus sqlquery::open_dbfile(tStr dbfn)$/;"	f	class:sqlquery
+open_file	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::open_file(const char *fn)$/;"	f	class:csdbparser
+open_files	makedb/ctagread.cpp	/^ctagread::enResult ctagread::open_files(const char* sqldb, const char* tagsfn)$/;"	f	class:ctagread
+operator !=	querylib/small_lib.cpp	/^bool smartFILE::operator !=(FILE* fptr) const {return (m_fp != fptr);}$/;"	f	class:smartFILE
+operator !=	querylib/small_lib.cpp	/^bool smartFILE::operator !=(const smartFILE& sfp) const {return (m_fp != sfp.m_fp);}$/;"	f	class:smartFILE
+operator !=	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::operator!=(const EdgeIterIface< EdgeIterImpl>& o) const$/;"	f	class:EdgeIterIface
+operator ()	querylib/small_lib.cpp	/^FILE* smartFILE::operator() () {return m_fp;}$/;"	f	class:smartFILE
+operator ()	querylib/small_lib.cpp	/^char* tempbuf::operator() () {return m_buffer;}$/;"	f	class:tempbuf
+operator *	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::operator*()$/;"	f	class:EdgeIterIface
+operator ++	querylib/small_lib.cpp	/^idxcounter& idxcounter::operator ++() {++m_ctr;sprintf(m_buf, "%lu", m_ctr); return *this;}$/;"	f	class:idxcounter
+operator ++	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::operator++( int)$/;"	f	class:EdgeIterIface
+operator ++	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::operator++()$/;"	f	class:EdgeIterIface
+operator --	querylib/small_lib.cpp	/^idxcounter& idxcounter::operator --() {--m_ctr;sprintf(m_buf, "%lu", m_ctr); return *this;}$/;"	f	class:idxcounter
+operator ->	showgraph/Utils/mem_ref.h	/^		inline RefObj* operator->()$/;"	f	class:Mem::Ref
+operator =	gui/fileviewer.cpp	/^filedata& filedata::operator=(const filedata& fd)$/;"	f	class:filedata
+operator =	gui/searchhandler.cpp	/^searchitem& searchitem::operator=(const searchitem& otheritem)$/;"	f	class:searchitem
+operator =	makedb/csdbparser.cpp	/^sym_data& sym_data::operator= (const sym_data& copy)$/;"	f	class:sym_data
+operator =	makedb/csdbparser.cpp	/^symdata_pack& symdata_pack::operator= (const symdata_pack& copy)$/;"	f	class:symdata_pack
+operator =	querylib/small_lib.cpp	/^idxcounter& idxcounter::operator =(const idxcounter& idxc)$/;"	f	class:idxcounter
+operator =	querylib/small_lib.cpp	/^idxcounter& idxcounter::operator =(long unsigned int idx) {m_ctr = idx; return *this;}$/;"	f	class:idxcounter
+operator =	querylib/small_lib.cpp	/^smartFILE& smartFILE::operator =(FILE *fptr) {setme(fptr); return *this;}$/;"	f	class:smartFILE
+operator =	querylib/small_lib.cpp	/^smartFILE& smartFILE::operator =(const smartFILE& sfp)$/;"	f	class:smartFILE
+operator =	querylib/sqlquery.cpp	/^sqlqueryresultlist& sqlqueryresultlist::operator= (const sqlqueryresultlist& copy)$/;"	f	class:sqlqueryresultlist
+operator =	showgraph/GraphView/gstyle.h	/^GStyle::operator = ( const GStyle& st)$/;"	f	class:GStyle
+operator =	showgraph/Utils/mem_mgr.h	/^        MemInfo& operator =( const MemInfo&){};$/;"	f	class:MemImpl::MemInfo
+operator =	showgraph/Utils/mem_pool.h	/^        PoolObj& operator = ( const PoolObj& obj){ return *this;};$/;"	f	class:Mem::PoolObj
+operator =	showgraph/Utils/mem_ref.h	/^		Ref< RefObj> & operator=( RefObj* p)$/;"	f	class:Mem::Ref
+operator =	showgraph/Utils/mem_ref.h	/^		Ref< RefObj> & operator=( const Ref< RefObj>& orig)$/;"	f	class:Mem::Ref
+operator =	showgraph/Utils/utils_utest.cpp	/^    classA& operator =( const classA&){};$/;"	f	class:classA	file:
+operator ==	querylib/small_lib.cpp	/^bool smartFILE::operator ==(FILE* fptr) const {return (m_fp == fptr);}$/;"	f	class:smartFILE
+operator ==	querylib/small_lib.cpp	/^bool smartFILE::operator ==(const smartFILE& sfp) const {return (m_fp == sfp.m_fp);}$/;"	f	class:smartFILE
+operator ==	showgraph/Graph/node_inline.h	/^EdgeIterIface< EdgeIterImpl>::operator==(const EdgeIterIface< EdgeIterImpl>& o) const$/;"	f	class:EdgeIterIface
+operator ==	showgraph/Graph/node_iter.h	/^    inline bool operator==(const PredIterImpl& o) const \/**< Comparison operator *\/$/;"	f	class:PredIterImpl
+operator ==	showgraph/Graph/node_iter.h	/^    inline bool operator==(const SuccIterImpl& o) const \/**< Comparison operator *\/$/;"	f	class:SuccIterImpl
+operator ==	showgraph/Graph/node_iter.h	/^    inline bool operator==(const UnDirIterImpl& o) const \/**< Comparison operator *\/$/;"	f	class:UnDirIterImpl
+operator ==	showgraph/Utils/mem_ref.h	/^		inline bool operator == ( Ref< RefObj> &r)$/;"	f	class:Mem::Ref
+operator RefObj*	showgraph/Utils/mem_ref.h	/^		inline operator RefObj*()$/;"	f	class:Mem::Ref
+operator []	querylib/small_lib.cpp	/^char  tempbuf::operator[] (unsigned int i)$/;"	f	class:tempbuf
+operator bool	showgraph/Utils/mem_ref.h	/^		inline operator bool()$/;"	f	class:Mem::Ref
+operator delete	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::operator delete( void* mem)$/;"	f	class:MemImpl::Chunk
+operator delete	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::operator delete( void* ptr, void* mem)$/;"	f	class:MemImpl::Chunk
+operator delete	showgraph/Utils/mem_pool.cpp	/^PoolObj::operator delete( void *ptr)$/;"	f	class:PoolObj
+operator delete	showgraph/Utils/mem_pool.h	/^    PoolObj::operator delete( void *ptr, Pool* pool)$/;"	f	class:Mem::PoolObj
+operator delete[]	showgraph/Utils/mem_pool.cpp	/^PoolObj::operator delete[]( void *ptr)$/;"	f	class:PoolObj
+operator new	showgraph/Utils/mem_chunk.h	/^    Chunk< Data>::operator new ( size_t size, void* mem)$/;"	f	class:MemImpl::Chunk
+operator new	showgraph/Utils/mem_pool.cpp	/^PoolObj::operator new( size_t size)$/;"	f	class:PoolObj
+operator new	showgraph/Utils/mem_pool.h	/^    PoolObj::operator new ( size_t size, Pool* pool)$/;"	f	class:Mem::PoolObj
+operator new[]	showgraph/Utils/mem_pool.cpp	/^PoolObj::operator new[]( size_t size)$/;"	f	class:PoolObj
+option	makedb/optlist.h	/^    char option;$/;"	m	struct:option_t
+option	showgraph/Utils/conf.h	/^    inline Option* option( QString name)$/;"	f	class:Conf
+option_t	makedb/optlist.h	/^typedef struct option_t$/;"	s
+option_t	makedb/optlist.h	/^} option_t;$/;"	t	typeref:struct:option_t
+order	showgraph/Layout/aux_graph.h	/^    Numeration order;$/;"	m	class:AuxGraph
+order	showgraph/Layout/aux_node.h	/^    inline int order() const$/;"	f	class:AuxNode
+orderNodesByDFS	showgraph/Layout/layout.cpp	/^void AuxGraph::orderNodesByDFS()$/;"	f	class:AuxGraph
+otherEnd	showgraph/GraphView/navigation.cpp	/^NodeNav::otherEnd( GEdge *edge) const$/;"	f	class:NodeNav
+out	showgraph/Utils/print.h	/^    inline void out( const char* format, ...)$/;"	f	namespace:PrintUtils
+paint	showgraph/GraphView/edge_helper.cpp	/^EdgeHelper::paint( QPainter *painter,$/;"	f	class:EdgeHelper
+paint	showgraph/GraphView/edge_item.cpp	/^EdgeItem::paint( QPainter *painter,$/;"	f	class:EdgeItem
+paint	showgraph/GraphView/node_item.cpp	/^NodeItem::paint( QPainter *painter,$/;"	f	class:NodeItem
+paintEvent	gui/obsolete/CodeEditor.h	/^     void paintEvent(QPaintEvent *event) {$/;"	f	class:LineNumberArea
+paintEvent	showgraph/GraphView/style_edit.cpp	/^void ColorButton::paintEvent( QPaintEvent *event)$/;"	f	class:ColorButton
+parse	makedb/csdbheader.cpp	/^bool csdbheader::parse(void)$/;"	f	class:csdbheader
+parse_headers	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::parse_headers(void)$/;"	f	class:csdbparser
+pattern	gui/obsolete/highlighter.h	/^         QRegExp pattern;$/;"	m	struct:Highlighter::HighlightingRule
+peer	showgraph/Utils/list.h	/^    ListItem<Data> * peer[ LIST_DIR_NUM];$/;"	m	class:ListItem
+peer	showgraph/Utils/list.h	/^    MListItem< 1> * peer[ LIST_DIR_NUM];$/;"	m	class:MListItem
+peer	showgraph/Utils/list.h	/^    MListItem< dim> * peer[ dim][ LIST_DIR_NUM];$/;"	m	class:MListItem
+peerInDir	showgraph/Utils/list.h	/^    inline MListItem< 1> * peerInDir( ListDir dir) const$/;"	f	class:MListItem
+peerInDir	showgraph/Utils/list.h	/^    inline MListItem< dim> * peerInDir( ListId list, ListDir dir) const$/;"	f	class:MListItem
+pen	showgraph/GraphView/gstyle.h	/^inline QPen GStyle::pen() const$/;"	f	class:GStyle
+pen_priv	showgraph/GraphView/gstyle.h	/^    QPen pen_priv;$/;"	m	class:GStyle
+perform_grep	gui/searchhandler.cpp	/^sqlqueryresultlist searchhandler::perform_grep(QString searchtxt, sqlqueryresultlist searchlist, bool exactmatch)$/;"	f	class:searchhandler
+perform_open_db	gui/searchhandler.cpp	/^void searchhandler::perform_open_db(void)$/;"	f	class:searchhandler
+perform_search	gui/searchhandler.cpp	/^void searchhandler::perform_search(QString searchtxt,$/;"	f	class:searchhandler
+placeNodes	showgraph/Layout/node_group.cpp	/^void NodeGroup::placeNodes()$/;"	f	class:NodeGroup
+placeNodesFinal	showgraph/Layout/node_group.cpp	/^void NodeGroup::placeNodesFinal( GraphDir dir)$/;"	f	class:NodeGroup
+pool	showgraph/Utils/mem_chunk.h	/^        void *pool;       $/;"	m	class:MemImpl::Chunk
+pool	showgraph/Utils/mem_obj.h	/^        inline Pool* pool() const$/;"	f	class:Mem::Obj
+populateList	gui/listhandler.cpp	/^void listhandler::populateList(sqlqueryresultlist resultlist, int selectitem)$/;"	f	class:listhandler
+pos	showgraph/Utils/mem_entry.h	/^    Entry< Data>::pos() const$/;"	f	class:MemImpl::Entry
+pred	showgraph/Graph/agraph.h	/^    inline ANode *pred() const $/;"	f	class:AEdge
+pred	showgraph/Graph/edge_inline.h	/^inline Node *Edge::pred() const$/;"	f	class:Edge
+pred	showgraph/GraphView/edge_item.h	/^    inline GNode *pred() const $/;"	f	class:GEdge
+pred	showgraph/GraphView/edge_item.h	/^    inline GNode* pred() const$/;"	f	class:EdgeItem
+pred	showgraph/GraphView/visible_edge.h	/^GNode* VEdge::pred() const$/;"	f	class:VEdge
+pred	showgraph/Layout/aux_edge.h	/^    inline AuxNode *pred() const $/;"	f	class:AuxEdge
+pred_priv	showgraph/GraphView/visible_edge.h	/^    GNode *pred_priv;$/;"	m	class:VEdge
+predsBegin	showgraph/Graph/node_inline.h	/^inline Node::Pred Node::predsBegin()$/;"	f	class:Node
+predsEnd	showgraph/Graph/node_inline.h	/^inline Node::Pred Node::predsEnd()$/;"	f	class:Node
+preferred_zoom	showgraph/GraphView/graph_view.h	/^    qreal preferred_zoom;$/;"	m	class:GraphView
+prepareToExit	gui/listhandler.cpp	/^void listhandler::prepareToExit(void)$/;"	f	class:listhandler
+prepareToExit	gui/mainwindow.cpp	/^void mainwindow::prepareToExit()$/;"	f	class:mainwindow
+prepare_cqdb	makedb/ctagread.cpp	/^ctagread::enResult ctagread::prepare_cqdb(void)$/;"	f	class:ctagread
+prepare_stmt	makedb/sqlbase.cpp	/^int sqlbase::prepare_stmt(sqlite3_stmt** pStmt, const char* sqlquery)$/;"	f	class:sqlbase
+prev	showgraph/GraphView/graph_view.cpp	/^NavEvent *GraphViewHistory::prev()$/;"	f	class:GraphViewHistory
+prev	showgraph/Utils/list.h	/^    inline Item* prev( ListId list) const$/;"	f	class:MListIface
+prev	showgraph/Utils/list.h	/^    inline Item* prev() const$/;"	f	class:MListIface
+prev	showgraph/Utils/list.h	/^    inline Item* prev() const$/;"	f	class:SListIface
+prev	showgraph/Utils/list.h	/^    inline ListItem<Data>* prev() const$/;"	f	class:ListItem
+prev	showgraph/Utils/list.h	/^    inline MListItem< 1>* prev() const$/;"	f	class:MListItem
+prev	showgraph/Utils/list.h	/^    inline MListItem< dim>* prev( ListId list) const$/;"	f	class:MListItem
+prevNode	showgraph/Graph/agraph.h	/^    inline ANode* prevNode()$/;"	f	class:ANode
+prevNode	showgraph/Graph/node_inline.h	/^inline Node* Node::prevNode()$/;"	f	class:Node
+prevNode	showgraph/GraphView/node_item.h	/^    inline GNode* prevNode()$/;"	f	class:GNode
+prevNode	showgraph/Layout/aux_node.h	/^    inline AuxNode* prevNode()$/;"	f	class:AuxNode
+print	showgraph/Utils/conf.cpp	/^Option::print( QTextStream &stream)$/;"	f	class:Option
+printDefaults	showgraph/Utils/conf.cpp	/^void Conf::printDefaults()$/;"	f	class:Conf
+printOpts	showgraph/Utils/conf.cpp	/^void Conf::printOpts()$/;"	f	class:Conf
+print_contents	makedb/csdbheader.cpp	/^void csdbheader::print_contents(void)$/;"	f	class:csdbheader
+printhelp	cli/main_cli.cpp	/^void printhelp(const char* str)$/;"	f
+printhelp	makedb/main.cpp	/^void printhelp(const char* str)$/;"	f
+printlicense	cli/main_cli.cpp	/^void printlicense(void)$/;"	f
+printlicense	makedb/main.cpp	/^void printlicense(void)$/;"	f
+priority	showgraph/Layout/aux_node.h	/^    inline int priority() const$/;"	f	class:AuxNode
+priv_field	showgraph/Utils/mem_utest.cpp	/^    quint32 priv_field;$/;"	m	class:MyPoolObj	file:
+priv_fixed	showgraph/Layout/aux_edge.h	/^    bool priv_fixed;$/;"	m	class:AuxEdge
+priv_height	showgraph/Layout/aux_node.h	/^    double priv_height;$/;"	m	class:AuxNode
+priv_level	showgraph/Layout/aux_node.h	/^    Level * priv_level;$/;"	m	class:AuxNode
+priv_order	showgraph/Layout/aux_node.h	/^    int priv_order;$/;"	m	class:AuxNode
+priv_priority	showgraph/Layout/aux_node.h	/^    int priv_priority;$/;"	m	class:AuxNode
+priv_rank	showgraph/Layout/aux_node.h	/^    Rank priv_rank;$/;"	m	class:AuxNode
+priv_type	showgraph/Layout/aux_edge.h	/^    AuxEdgeType priv_type;$/;"	m	class:AuxEdge
+priv_width	showgraph/Layout/aux_node.h	/^    double priv_width;$/;"	m	class:AuxNode
+priv_x	showgraph/Layout/aux_node.h	/^    double priv_x;$/;"	m	class:AuxNode
+priv_y	showgraph/Layout/aux_node.h	/^    double priv_y;$/;"	m	class:AuxNode
+process_argwithopt	cli/main_cli.cpp	/^void process_argwithopt(option_t* thisOpt, bool& err, tStr& fnstr, bool filemustexist)$/;"	f
+process_argwithopt	makedb/main.cpp	/^void process_argwithopt(option_t* thisOpt, bool& err, std::string& fnstr, bool filemustexist)$/;"	f
+process_cscope	makedb/main.cpp	/^int process_cscope(const char* cscopefn, const char* sqfn, bool debug)$/;"	f
+process_ctags	makedb/ctagread.cpp	/^ctagread::enResult ctagread::process_ctags(void)$/;"	f	class:ctagread
+process_ctags	makedb/main.cpp	/^int process_ctags(const char* ctagsfn, const char* sqfn, bool debug)$/;"	f
+process_query	cli/main_cli.cpp	/^int process_query(tStr sqfn, tStr term, tStr param, bool exact, bool debug)$/;"	f
+process_searchterm	querylib/sqlquery.cpp	/^tStr sqlquery::process_searchterm(const char* searchterm, const bool& exactmatch)$/;"	f	class:sqlquery
+process_searchterm_autocomplete	querylib/sqlquery.cpp	/^tStr sqlquery::process_searchterm_autocomplete(const char* searchterm)$/;"	f	class:sqlquery
+processfile	gui/themes/parse_themes.pl	/^sub processfile$/;"	s
+ptr	showgraph/Utils/mem_ref.h	/^		RefObj *ptr;$/;"	m	class:Mem::Ref
+pyAdditionalRules	gui/obsolete/highlighter.cpp	/^ void Highlighter::pyAdditionalRules(const QString &text)$/;"	f	class:Highlighter
+pyHighlightingRules	gui/obsolete/highlighter.h	/^     QVector<HighlightingRule> pyHighlightingRules;$/;"	m	class:Highlighter
+python_Bespin	gui/themes_gen.cpp	/^static const lexstyle python_Bespin[] = {$/;"	v	file:
+python_Black_board	gui/themes_gen.cpp	/^static const lexstyle python_Black_board[] = {$/;"	v	file:
+python_Choco	gui/themes_gen.cpp	/^static const lexstyle python_Choco[] = {$/;"	v	file:
+python_Deep_Black	gui/themes_gen.cpp	/^static const lexstyle python_Deep_Black[] = {$/;"	v	file:
+python_Eclipse_Default	gui/themes_gen.cpp	/^static const lexstyle python_Eclipse_Default[] = {$/;"	v	file:
+python_Hello_Kitty	gui/themes_gen.cpp	/^static const lexstyle python_Hello_Kitty[] = {$/;"	v	file:
+python_HotFudgeSundae	gui/themes_gen.cpp	/^static const lexstyle python_HotFudgeSundae[] = {$/;"	v	file:
+python_Mono_Industrial	gui/themes_gen.cpp	/^static const lexstyle python_Mono_Industrial[] = {$/;"	v	file:
+python_Monokai	gui/themes_gen.cpp	/^static const lexstyle python_Monokai[] = {$/;"	v	file:
+python_MossyLawn	gui/themes_gen.cpp	/^static const lexstyle python_MossyLawn[] = {$/;"	v	file:
+python_Navajo	gui/themes_gen.cpp	/^static const lexstyle python_Navajo[] = {$/;"	v	file:
+python_NotepadPlusPlus	gui/themes_gen.cpp	/^static const lexstyle python_NotepadPlusPlus[] = {$/;"	v	file:
+python_Obsidian	gui/themes_gen.cpp	/^static const lexstyle python_Obsidian[] = {$/;"	v	file:
+python_Plastic_Code_Wrap	gui/themes_gen.cpp	/^static const lexstyle python_Plastic_Code_Wrap[] = {$/;"	v	file:
+python_Ruby_Blue	gui/themes_gen.cpp	/^static const lexstyle python_Ruby_Blue[] = {$/;"	v	file:
+python_Solarized	gui/themes_gen.cpp	/^static const lexstyle python_Solarized[] = {$/;"	v	file:
+python_Solarized_light	gui/themes_gen.cpp	/^static const lexstyle python_Solarized_light[] = {$/;"	v	file:
+python_Twilight	gui/themes_gen.cpp	/^static const lexstyle python_Twilight[] = {$/;"	v	file:
+python_Vibrant_Ink	gui/themes_gen.cpp	/^static const lexstyle python_Vibrant_Ink[] = {$/;"	v	file:
+python_Zenburn	gui/themes_gen.cpp	/^static const lexstyle python_Zenburn[] = {$/;"	v	file:
+python_khaki	gui/themes_gen.cpp	/^static const lexstyle python_khaki[] = {$/;"	v	file:
+python_vim_Dark_Blue	gui/themes_gen.cpp	/^static const lexstyle python_vim_Dark_Blue[] = {$/;"	v	file:
+pythonstyle	gui/themes_gen.cpp	/^static const langstyle pythonstyle[] = {$/;"	v	file:
+qry	querylib/sqlquery.h	/^tStr qry;$/;"	m	class:tempstmt
+qt2str	gui/std2qt.h	/^inline tStr qt2str(const QString& inp)$/;"	f
+qt2strLst	gui/std2qt.cpp	/^tVecStr qt2strLst(const QStringList& inpLst)$/;"	f
+qtype	gui/searchhandler.h	/^	sqlquery::en_queryType qtype;$/;"	m	class:searchitem
+quotationFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat quotationFormat;$/;"	m	class:Highlighter
+rank	showgraph/Layout/aux_graph.h	/^    inline Rank rank() const$/;"	f	class:Level
+rank	showgraph/Layout/aux_node.h	/^    inline int rank() const$/;"	f	class:AuxNode
+rankNodes	showgraph/Layout/layout.cpp	/^Numeration AuxGraph::rankNodes()$/;"	f	class:AuxGraph
+ranking	showgraph/Layout/aux_graph.h	/^    Numeration ranking;$/;"	m	class:AuxGraph
+rankingValid	showgraph/Layout/aux_graph.h	/^    inline bool rankingValid() const$/;"	f	class:AuxGraph
+ranking_valid	showgraph/Layout/aux_graph.h	/^    bool ranking_valid;$/;"	m	class:AuxGraph
+ranks	showgraph/Layout/aux_graph.h	/^    inline Numeration ranks() const$/;"	f	class:AuxGraph
+rboxPath	showgraph/GraphView/node_item.cpp	/^inline QPainterPath rboxPath( QRectF rect)$/;"	f
+rboxRect	showgraph/GraphView/node_item.cpp	/^inline QRectF rboxRect( QRectF rect)$/;"	f
+readArgs	showgraph/Utils/conf.cpp	/^void Conf::readArgs( int argc, char** argv)$/;"	f	class:Conf
+readFromElement	showgraph/Graph/edge.cpp	/^Edge::readFromElement( QDomElement e)$/;"	f	class:Edge
+readFromElement	showgraph/Graph/node_inline.h	/^Node::readFromElement( QDomElement e)$/;"	f	class:Node
+readFromElement	showgraph/GraphView/edge_item.cpp	/^GEdge::readFromElement( QDomElement e)$/;"	f	class:GEdge
+readFromElement	showgraph/GraphView/node_item.cpp	/^GNode::readFromElement( QDomElement e)$/;"	f	class:GNode
+readFromXML	showgraph/Graph/graph.cpp	/^Graph::readFromXML( QString txt) \/\/ changed to read from QString rather than from file$/;"	f	class:Graph
+readFromXML	showgraph/GraphView/graph_view.cpp	/^GGraph::readFromXML( QString txt)$/;"	f	class:GGraph
+readSettings	gui/mainwindow.cpp	/^void mainwindow::readSettings()$/;"	f	class:mainwindow
+read_configtbl	querylib/sqlquery.cpp	/^tStr sqlquery::read_configtbl(const char *key, sqlite3_stmt *stmt)$/;"	f	class:sqlquery
+realNode	showgraph/GraphView/edge_item.cpp	/^GEdge::realNode( GraphDir dir) const $/;"	f	class:GEdge
+realNode	showgraph/Layout/aux_edge.h	/^	inline AuxNode* realNode( GraphDir dir) const$/;"	f	class:AuxEdge
+realPred	showgraph/GraphView/edge_item.h	/^    inline GNode* realPred() const$/;"	f	class:GEdge
+realPred	showgraph/Layout/aux_edge.h	/^	inline AuxNode* realPred() const$/;"	f	class:AuxEdge
+realSucc	showgraph/GraphView/edge_item.h	/^    inline GNode* realSucc() const$/;"	f	class:GEdge
+realSucc	showgraph/Layout/aux_edge.h	/^	inline AuxNode* realSucc() const$/;"	f	class:AuxEdge
+recvDBtimestamp	gui/fileviewer.cpp	/^void fileviewer::recvDBtimestamp(QDateTime dt)$/;"	f	class:fileviewer
+reduceCrossings	showgraph/Layout/layout.cpp	/^void AuxGraph::reduceCrossings()$/;"	f	class:AuxGraph
+refCount	showgraph/Utils/mem_obj.h	/^		inline RefNumber refCount() const$/;"	f	class:Mem::Obj
+ref_count	showgraph/Utils/mem_obj.h	/^		RefNumber ref_count; \/* Additional memory used, the overhead of counted references *\/$/;"	m	class:Mem::Obj
+reinit	querylib/small_lib.cpp	/^char* tempbuf::reinit(unsigned int n)$/;"	f	class:tempbuf
+remove	showgraph/GraphView/edge_item.h	/^    inline void remove()$/;"	f	class:EdgeItem
+remove	showgraph/GraphView/node_item.h	/^    inline void remove()$/;"	f	class:NodeItem
+remove_symname	gui/sqlqueryadv.cpp	/^void sqlqueryadv::remove_symname(sqlqueryresultlist& res, tStr name)$/;"	f	class:sqlqueryadv
+replaceLexer	gui/fileviewer.cpp	/^void fileviewer::replaceLexer(const char* langstr, int lang)$/;"	f	class:fileviewer
+replacechar	querylib/small_lib.cpp	/^int replacechar(std::string::iterator i1, std::string::iterator i2, const char o, const char r)$/;"	f
+replayNavigationEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::replayNavigationEvent( NavEvent *ev)$/;"	f	class:GraphView
+requestToProvideResultCurrentListItemSymbolName	gui/listhandler.cpp	/^void listhandler::requestToProvideResultCurrentListItemSymbolName()$/;"	f	class:listhandler
+resCSDBPError	makedb/cs2sq.h	/^	resCSDBPError,$/;"	e	enum:cs2sq::enResult
+resCSDBPFileNotOpen	makedb/cs2sq.h	/^	resCSDBPFileNotOpen,$/;"	e	enum:cs2sq::enResult
+resFILE_ACCESS_ERR	makedb/cs2sq.h	/^	resFILE_ACCESS_ERR,$/;"	e	enum:cs2sq::enResult
+resFILE_ACCESS_ERR	makedb/csdbparser.h	/^   resFILE_ACCESS_ERR,$/;"	e	enum:csdbparser::enResult
+resFILE_ACCESS_ERR	makedb/ctagread.h	/^   resFILE_ACCESS_ERR,$/;"	e	enum:ctagread::enResult
+resFILE_NOT_FOUND	makedb/csdbparser.h	/^   resFILE_NOT_FOUND,$/;"	e	enum:csdbparser::enResult
+resFILE_NOT_FOUND	makedb/ctagread.h	/^   resFILE_NOT_FOUND,$/;"	e	enum:ctagread::enResult
+resFILE_NOT_OPEN	makedb/csdbparser.h	/^   resFILE_NOT_OPEN$/;"	e	enum:csdbparser::enResult
+resFILE_NOT_OPEN	makedb/ctagread.h	/^   resFILE_NOT_OPEN$/;"	e	enum:ctagread::enResult
+resFilenameError	makedb/cs2sq.h	/^	resFilenameError,$/;"	e	enum:cs2sq::enResult
+resINCORRECT_VER	makedb/csdbparser.h	/^   resINCORRECT_VER,$/;"	e	enum:csdbparser::enResult
+resINCORRECT_VER	makedb/ctagread.h	/^   resINCORRECT_VER,$/;"	e	enum:ctagread::enResult
+resOK	makedb/cs2sq.h	/^	resOK = 0,$/;"	e	enum:cs2sq::enResult
+resOK	makedb/csdbparser.h	/^   resOK = 0,$/;"	e	enum:csdbparser::enResult
+resOK	makedb/ctagread.h	/^   resOK = 0,$/;"	e	enum:ctagread::enResult
+resOTHER_ERR	makedb/cs2sq.h	/^	resOTHER_ERR$/;"	e	enum:cs2sq::enResult
+resOTHER_ERR	makedb/csdbparser.h	/^   resOTHER_ERR,$/;"	e	enum:csdbparser::enResult
+resOTHER_ERR	makedb/ctagread.h	/^   resOTHER_ERR,$/;"	e	enum:ctagread::enResult
+resSQLError	makedb/cs2sq.h	/^	resSQLError,$/;"	e	enum:cs2sq::enResult
+resSQLError	makedb/ctagread.h	/^   resSQLError,$/;"	e	enum:ctagread::enResult
+resUNKNOWN_ERR	makedb/csdbparser.h	/^   resUNKNOWN_ERR,$/;"	e	enum:csdbparser::enResult
+resUNKNOWN_ERR	makedb/ctagread.h	/^   resUNKNOWN_ERR,$/;"	e	enum:ctagread::enResult
+resUNRECOG_FORMAT	makedb/csdbparser.h	/^   resUNRECOG_FORMAT,$/;"	e	enum:csdbparser::enResult
+resUNRECOG_FORMAT	makedb/ctagread.h	/^   resUNRECOG_FORMAT,$/;"	e	enum:ctagread::enResult
+resUNSUPPORTED_PARAM	makedb/csdbparser.h	/^   resUNSUPPORTED_PARAM,$/;"	e	enum:csdbparser::enResult
+resUNSUPPORTED_PARAM	makedb/ctagread.h	/^   resUNSUPPORTED_PARAM,$/;"	e	enum:ctagread::enResult
+reset	querylib/small_lib.cpp	/^void idxcounter::reset(void) {m_ctr = 0;}$/;"	f	class:idxcounter
+reset	showgraph/GraphView/edge_helper.h	/^EdgeHelper::reset()$/;"	f	class:EdgeHelper
+resizeColumns	gui/listhandler.cpp	/^void listhandler::resizeColumns(void)$/;"	f	class:listhandler
+resizeEvent	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::resizeEvent(QResizeEvent *e)$/;"	f	class:CodeEditor
+restoreSearchMemoryItem	gui/searchhandler.cpp	/^void searchhandler::restoreSearchMemoryItem(void)$/;"	f	class:searchhandler
+resultCurrentListItemSymbolName	gui/searchhandler.cpp	/^void searchhandler::resultCurrentListItemSymbolName(const QString symName)$/;"	f	class:searchhandler
+result_type	querylib/sqlquery.h	/^	en_resultType result_type;$/;"	m	class:sqlqueryresultlist
+resultlist	querylib/sqlquery.h	/^	std::vector<sqlqueryresult> resultlist;$/;"	m	class:sqlqueryresultlist
+retranslateUi	gui/listhandler.cpp	/^void listhandler::retranslateUi(void)$/;"	f	class:listhandler
+retranslateUi	gui/mainwindow.cpp	/^void mainwindow::retranslateUi(void)$/;"	f	class:mainwindow
+retranslateUi	gui/searchhandler.cpp	/^void searchhandler::retranslateUi(void)$/;"	f	class:searchhandler
+right	showgraph/Layout/node_group.h	/^    inline qreal right() const$/;"	f	class:NodeGroup
+rootNode	showgraph/Layout/aux_graph.cpp	/^AuxGraph::rootNode()$/;"	f	class:AuxGraph
+rownum	gui/searchhandler.h	/^	int rownum;$/;"	m	class:searchitem
+ruby_Bespin	gui/themes_gen.cpp	/^static const lexstyle ruby_Bespin[] = {$/;"	v	file:
+ruby_Black_board	gui/themes_gen.cpp	/^static const lexstyle ruby_Black_board[] = {$/;"	v	file:
+ruby_Choco	gui/themes_gen.cpp	/^static const lexstyle ruby_Choco[] = {$/;"	v	file:
+ruby_Deep_Black	gui/themes_gen.cpp	/^static const lexstyle ruby_Deep_Black[] = {$/;"	v	file:
+ruby_Eclipse_Default	gui/themes_gen.cpp	/^static const lexstyle ruby_Eclipse_Default[] = {$/;"	v	file:
+ruby_Hello_Kitty	gui/themes_gen.cpp	/^static const lexstyle ruby_Hello_Kitty[] = {$/;"	v	file:
+ruby_HotFudgeSundae	gui/themes_gen.cpp	/^static const lexstyle ruby_HotFudgeSundae[] = {$/;"	v	file:
+ruby_Mono_Industrial	gui/themes_gen.cpp	/^static const lexstyle ruby_Mono_Industrial[] = {$/;"	v	file:
+ruby_Monokai	gui/themes_gen.cpp	/^static const lexstyle ruby_Monokai[] = {$/;"	v	file:
+ruby_MossyLawn	gui/themes_gen.cpp	/^static const lexstyle ruby_MossyLawn[] = {$/;"	v	file:
+ruby_Navajo	gui/themes_gen.cpp	/^static const lexstyle ruby_Navajo[] = {$/;"	v	file:
+ruby_NotepadPlusPlus	gui/themes_gen.cpp	/^static const lexstyle ruby_NotepadPlusPlus[] = {$/;"	v	file:
+ruby_Obsidian	gui/themes_gen.cpp	/^static const lexstyle ruby_Obsidian[] = {$/;"	v	file:
+ruby_Plastic_Code_Wrap	gui/themes_gen.cpp	/^static const lexstyle ruby_Plastic_Code_Wrap[] = {$/;"	v	file:
+ruby_Ruby_Blue	gui/themes_gen.cpp	/^static const lexstyle ruby_Ruby_Blue[] = {$/;"	v	file:
+ruby_Solarized	gui/themes_gen.cpp	/^static const lexstyle ruby_Solarized[] = {$/;"	v	file:
+ruby_Solarized_light	gui/themes_gen.cpp	/^static const lexstyle ruby_Solarized_light[] = {$/;"	v	file:
+ruby_Twilight	gui/themes_gen.cpp	/^static const lexstyle ruby_Twilight[] = {$/;"	v	file:
+ruby_Vibrant_Ink	gui/themes_gen.cpp	/^static const lexstyle ruby_Vibrant_Ink[] = {$/;"	v	file:
+ruby_Zenburn	gui/themes_gen.cpp	/^static const lexstyle ruby_Zenburn[] = {$/;"	v	file:
+ruby_khaki	gui/themes_gen.cpp	/^static const lexstyle ruby_khaki[] = {$/;"	v	file:
+ruby_vim_Dark_Blue	gui/themes_gen.cpp	/^static const lexstyle ruby_vim_Dark_Blue[] = {$/;"	v	file:
+rubystyle	gui/themes_gen.cpp	/^static const langstyle rubystyle[] = {$/;"	v	file:
+runLayout	showgraph/GraphView/graph_view.cpp	/^void GraphView::runLayout()$/;"	f	class:GraphView
+runLayoutAct	showgraph/GraphView/graph_view.h	/^    QAction *runLayoutAct;$/;"	m	class:GraphView
+savetodotfile	gui/graphdialog.cpp	/^void cqDialogGraph::savetodotfile()$/;"	f	class:cqDialogGraph
+savetoimagefile	gui/graphdialog.cpp	/^void cqDialogGraph::savetoimagefile()$/;"	f	class:cqDialogGraph
+scaleImage	gui/graphdialog.cpp	/^void cqDialogGraph::scaleImage(double factor)$/;"	f	class:cqDialogGraph
+scaleVal	showgraph/GraphView/graph_view.cpp	/^inline qreal scaleVal( qreal zoom_scale)$/;"	f
+search	querylib/sqlquery.cpp	/^sqlqueryresultlist sqlquery::search($/;"	f	class:sqlquery
+searchNode	showgraph/GraphView/graph_view.h	/^    inline GNode * searchNode() const$/;"	f	class:GraphView
+searchTextEdited	gui/searchhandler.cpp	/^void searchhandler::searchTextEdited(const QString& searchtxt)$/;"	f	class:searchhandler
+search_autocomplete	querylib/sqlquery.cpp	/^tVecStr sqlquery::search_autocomplete(const char* searchstr)$/;"	f	class:sqlquery
+search_autocomplete_qt	gui/searchhandler.cpp	/^QStringList searchhandler::search_autocomplete_qt(QString searchtxt)$/;"	f	class:searchhandler
+search_classinheritgraph	gui/sqlqueryadv.cpp	/^bool sqlqueryadv::search_classinheritgraph(QString searchstr, bool exactmatch, QString& xmlout, QString& dotout)$/;"	f	class:sqlqueryadv
+search_file_line	querylib/sqlquery.cpp	/^sqlqueryresultlist sqlquery::search_file_line(sqlite3_stmt* stmt)$/;"	f	class:sqlquery
+search_file_only	querylib/sqlquery.cpp	/^sqlqueryresultlist sqlquery::search_file_only(sqlite3_stmt* stmt)$/;"	f	class:sqlquery
+search_full	querylib/sqlquery.cpp	/^sqlqueryresultlist sqlquery::search_full(sqlite3_stmt* stmt)$/;"	f	class:sqlquery
+search_funcgraph	gui/sqlqueryadv.cpp	/^bool sqlqueryadv::search_funcgraph(QString searchstr, bool exactmatch, QString& xmlout, QString& dotout)$/;"	f	class:sqlqueryadv
+search_node	showgraph/GraphView/graph_view.h	/^    GNode *search_node;$/;"	m	class:GraphView
+searchhandler	gui/searchhandler.cpp	/^searchhandler::searchhandler(mainwindow* pmw)$/;"	f	class:searchhandler
+searchhandler	gui/searchhandler.h	/^class searchhandler : public QObject$/;"	c
+searchitem	gui/searchhandler.cpp	/^searchitem::searchitem()$/;"	f	class:searchitem
+searchitem	gui/searchhandler.cpp	/^searchitem::searchitem(const searchitem& otheritem)$/;"	f	class:searchitem
+searchitem	gui/searchhandler.h	/^class searchitem$/;"	c
+searchterm	gui/searchhandler.h	/^	QString searchterm;$/;"	m	class:searchitem
+sector	showgraph/GraphView/navigation.h	/^NavSector NodeNav::sector() const$/;"	f	class:NodeNav
+sectorMaxAngle	showgraph/GraphView/navigation.cpp	/^qreal NodeNav::sectorMaxAngle() const$/;"	f	class:NodeNav
+sectorMinAngle	showgraph/GraphView/navigation.cpp	/^qreal NodeNav::sectorMinAngle() const$/;"	f	class:NodeNav
+sector_priv	showgraph/GraphView/navigation.h	/^    NavSector sector_priv;$/;"	m	class:NodeNav
+sel_edges	showgraph/GraphView/graph_view.h	/^    QList< GEdge* > sel_edges;$/;"	m	class:GGraph
+sel_nodes	showgraph/GraphView/graph_view.h	/^    QList< GNode* > sel_nodes;$/;"	m	class:GGraph
+selectEdge	showgraph/GraphView/graph_view.h	/^    inline void selectEdge( GEdge *e)$/;"	f	class:GGraph
+selectFillColor	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::selectFillColor()$/;"	f	class:StyleEdit
+selectLineColor	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::selectLineColor()$/;"	f	class:StyleEdit
+selectNode	showgraph/GraphView/graph_view.h	/^    inline void selectNode( GNode *n)$/;"	f	class:GGraph
+selectOneNode	showgraph/GraphView/graph_view.cpp	/^void GGraph::selectOneNode( GNode* n)$/;"	f	class:GGraph
+selfEdgePath	showgraph/GraphView/edge_helper.cpp	/^QPainterPath EdgeHelper::selfEdgePath() const$/;"	f	class:EdgeHelper
+selfEdgePath	showgraph/GraphView/edge_item.cpp	/^QPainterPath EdgeItem::selfEdgePath() const$/;"	f	class:EdgeItem
+setBack	showgraph/Layout/aux_edge.h	/^    inline void setBack()$/;"	f	class:AuxEdge
+setBc	showgraph/Layout/aux_node.h	/^    inline void setBc( qreal center)$/;"	f	class:AuxNode
+setBoolVal	showgraph/Utils/conf.h	/^    inline void setBoolVal( bool val)$/;"	f	class:Option
+setBrush	showgraph/GraphView/gstyle.h	/^inline void GStyle::setBrush( QBrush &br)$/;"	f	class:GStyle
+setBrushColor	showgraph/GraphView/gstyle.h	/^inline void GStyle::setBrushColor( QColor &color)$/;"	f	class:GStyle
+setColor	showgraph/GraphView/style_edit.h	/^    void setColor( QColor &cl)            $/;"	f	class:ColorButton
+setCounterVal	querylib/small_lib.cpp	/^void idxcounter::setCounterVal(long unsigned int i) {m_ctr = i;}$/;"	f	class:idxcounter
+setCurrPos	showgraph/GraphView/graph_view.h	/^    inline void setCurrPos( QPointF p)$/;"	f	class:GraphView
+setCurrentFontType	gui/fileviewsettingsdialog.cpp	/^void cqDialogFileViewSettings::setCurrentFontType(const QString& fonttype)$/;"	f	class:cqDialogFileViewSettings
+setCurrentTheme	gui/fileviewsettingsdialog.cpp	/^void cqDialogFileViewSettings::setCurrentTheme(const QString& theme)$/;"	f	class:cqDialogFileViewSettings
+setData	showgraph/Utils/list.h	/^    inline void setData( Data* d)$/;"	f	class:ListItem
+setDebug	makedb/csdbparser.cpp	/^void csdbparser::setDebug(bool val)$/;"	f	class:csdbparser
+setDebug	makedb/sqlbase.cpp	/^void sqlbase::setDebug(bool val)$/;"	f	class:sqlbase
+setDefined	showgraph/Utils/conf.h	/^    inline void setDefined( bool def = true)$/;"	f	class:Option
+setDoc	showgraph/GraphView/node_item.h	/^    inline void setDoc( QTextDocument* doc)$/;"	f	class:GNode
+setDst	showgraph/GraphView/edge_helper.h	/^EdgeHelper::setDst( NodeItem *item)$/;"	f	class:EdgeHelper
+setDstP	showgraph/GraphView/edge_helper.h	/^EdgeHelper::setDstP( QPointF p)$/;"	f	class:EdgeHelper
+setEdge	showgraph/Graph/node_iter.h	/^    inline void setEdge( Edge *e){ edge_p = e;}$/;"	f	class:IterImplBase
+setEdgeStyle	showgraph/GraphView/graph_view.cpp	/^void GGraph::setEdgeStyle( GStyle *style)$/;"	f	class:GGraph
+setEdgeStyle	showgraph/GraphView/graph_view.cpp	/^void GraphView::setEdgeStyle( GStyle *style)$/;"	f	class:GraphView
+setEditable	showgraph/GraphView/graph_view.h	/^    inline void setEditable( bool val = true)$/;"	f	class:GraphView
+setElement	showgraph/Graph/edge_inline.h	/^inline void Edge::setElement( QDomElement elem)$/;"	f	class:Edge
+setElement	showgraph/Graph/node_inline.h	/^inline void Node::setElement( QDomElement elem)$/;"	f	class:Node
+setFixed	showgraph/Layout/aux_edge.h	/^    inline void setFixed( bool fx)$/;"	f	class:AuxEdge
+setFloatVal	showgraph/Utils/conf.h	/^    inline void setFloatVal( qreal val)$/;"	f	class:Option
+setForPlacement	showgraph/Layout/aux_node.h	/^    inline void setForPlacement( bool placed = true)$/;"	f	class:AuxNode
+setForward	showgraph/Layout/aux_edge.h	/^    inline void setForward()$/;"	f	class:AuxEdge
+setGStyle	showgraph/GraphView/style_edit.cpp	/^void StyleEdit::setGStyle( GStyle *st)$/;"	f	class:StyleEdit
+setGraph	showgraph/GraphView/graph_view.h	/^    inline void setGraph( GGraph *g)$/;"	f	class:GraphView
+setHeight	showgraph/Layout/aux_graph.h	/^    inline void setHeight( qreal h)$/;"	f	class:Level
+setHeight	showgraph/Layout/aux_node.h	/^    inline void setHeight( double h) $/;"	f	class:AuxNode
+setIRId	showgraph/GraphView/node_item.h	/^	inline void setIRId( GraphNum i)$/;"	f	class:GNode
+setIntVal	showgraph/Utils/conf.h	/^    inline void setIntVal( int val)$/;"	f	class:Option
+setLeft	showgraph/Layout/node_group.h	/^    inline void setLeft( qreal pos)$/;"	f	class:NodeGroup
+setLevel	showgraph/Layout/aux_node.h	/^    inline void setLevel( Level* l) $/;"	f	class:AuxNode
+setLexer	gui/fileviewer.cpp	/^void fileviewer::setLexer(int lang)$/;"	f	class:fileviewer
+setMode	showgraph/GraphView/edge_item.h	/^    inline void setMode( EdgeMode m)$/;"	f	class:EdgeItem
+setName	showgraph/GraphView/gstyle.h	/^inline void GStyle::setName( QString &str)$/;"	f	class:GStyle
+setNext	showgraph/Utils/list.h	/^    inline void setNext( ListId list, MListItem< dim> *n)$/;"	f	class:MListItem
+setNext	showgraph/Utils/list.h	/^    inline void setNext( MListItem< 1> *n)$/;"	f	class:MListItem
+setNextFree	showgraph/Utils/mem_entry.h	/^    Entry< Data>::setNextFree( ChunkPos next)$/;"	f	class:MemImpl::Entry
+setNode	showgraph/Graph/edge_inline.h	/^Edge::setNode( Node *n, GraphDir dir)$/;"	f	class:Edge
+setNode	showgraph/GraphView/edge_item.h	/^    inline void setNode( GNode *n, GraphDir dir)$/;"	f	class:GEdge
+setNode	showgraph/GraphView/graph_view.h	/^    inline void setNode( GNode *n)$/;"	f	class:NavEvent
+setNodeInFocus	showgraph/GraphView/graph_view.h	/^    inline void setNodeInFocus( GNode *n, NavSector sector = UNDEF_SECTOR)$/;"	f	class:GGraph
+setNodeStyle	showgraph/GraphView/graph_view.cpp	/^void GGraph::setNodeStyle( GStyle *style)$/;"	f	class:GGraph
+setNodeStyle	showgraph/GraphView/graph_view.cpp	/^void GraphView::setNodeStyle( GStyle *style)$/;"	f	class:GraphView
+setNumber	showgraph/Graph/num.h	/^Numbered::setNumber( Numeration num,$/;"	f	class:Numbered
+setOpacityLevel	showgraph/GraphView/node_item.h	/^    inline void setOpacityLevel( qreal op_l)$/;"	f	class:NodeItem
+setOrder	showgraph/Layout/aux_node.h	/^    inline void setOrder( int order)$/;"	f	class:AuxNode
+setPeerInDir	showgraph/Utils/list.h	/^    inline void setPeerInDir( ListId list, MListItem< dim> *p, ListDir dir)$/;"	f	class:MListItem
+setPeerInDir	showgraph/Utils/list.h	/^    inline void setPeerInDir( MListItem< 1> *p, ListDir dir)$/;"	f	class:MListItem
+setPen	showgraph/GraphView/gstyle.h	/^inline void GStyle::setPen( QPen &pn)$/;"	f	class:GStyle
+setPenColor	showgraph/GraphView/gstyle.h	/^inline void GStyle::setPenColor( QColor &color)$/;"	f	class:GStyle
+setPenStyle	showgraph/GraphView/gstyle.h	/^inline void GStyle::setPenStyle( Qt::PenStyle st)$/;"	f	class:GStyle
+setPenWidth	showgraph/GraphView/gstyle.h	/^inline void GStyle::setPenWidth( qreal width)$/;"	f	class:GStyle
+setPos	showgraph/Utils/mem_entry.h	/^    Entry< Data>::setPos( ChunkPos pos)$/;"	f	class:MemImpl::Entry
+setPred	showgraph/Graph/edge_inline.h	/^inline void Edge::setPred( Node *n)$/;"	f	class:Edge
+setPred	showgraph/GraphView/edge_item.h	/^    inline void setPred( GNode *n)$/;"	f	class:GEdge
+setPrev	showgraph/Utils/list.h	/^    inline void setPrev( ListId list, MListItem< dim> *p)$/;"	f	class:MListItem
+setPrev	showgraph/Utils/list.h	/^    inline void setPrev( MListItem< 1> *p)$/;"	f	class:MListItem
+setPriority	showgraph/Layout/aux_node.h	/^    inline void setPriority( int p) $/;"	f	class:AuxNode
+setRank	showgraph/Layout/aux_graph.h	/^    inline void setRank( Rank r)$/;"	f	class:Level
+setRank	showgraph/Layout/aux_node.h	/^    inline void setRank( Rank r)$/;"	f	class:AuxNode
+setRight	showgraph/Layout/node_group.h	/^    inline void setRight( qreal pos)$/;"	f	class:NodeGroup
+setSelf	showgraph/Layout/aux_edge.h	/^    inline void setSelf()$/;"	f	class:AuxEdge
+setShape	showgraph/GraphView/gstyle.h	/^inline void GStyle::setShape( NodeShape new_shape)$/;"	f	class:GStyle
+setSrc	showgraph/GraphView/edge_helper.h	/^EdgeHelper::setSrc( NodeItem *item)$/;"	f	class:EdgeHelper
+setStable	showgraph/Layout/aux_node.h	/^    inline void setStable( bool st = true)$/;"	f	class:AuxNode
+setState	showgraph/GraphView/gstyle.h	/^inline void GStyle::setState( bool default_state)$/;"	f	class:GStyle
+setStringVal	showgraph/Utils/conf.h	/^    inline void setStringVal( QString val)$/;"	f	class:Option
+setStyle	showgraph/GraphView/edge_item.h	/^inline void GEdge::setStyle( GStyle *st)$/;"	f	class:GEdge
+setStyle	showgraph/GraphView/node_item.h	/^    inline void setStyle( GStyle *st)$/;"	f	class:GNode
+setStyleEditInfo	showgraph/GraphView/graph_view.h	/^    inline void setStyleEditInfo( StyleEditInfo* info)$/;"	f	class:GraphView
+setSucc	showgraph/Graph/edge_inline.h	/^inline void Edge::setSucc( Node *n)$/;"	f	class:Edge
+setSucc	showgraph/GraphView/edge_item.h	/^    inline void setSucc( GNode *n)$/;"	f	class:GEdge
+setTabWidth	gui/fileviewsettingsdialog.cpp	/^void cqDialogFileViewSettings::setTabWidth(const int& width)$/;"	f	class:cqDialogFileViewSettings
+setTextDock	showgraph/GraphView/node_item.h	/^	inline void setTextDock( QDockWidget *dock)$/;"	f	class:NodeItem
+setTextShown	showgraph/GraphView/node_item.h	/^	inline void setTextShown( bool shown = true)$/;"	f	class:GNode
+setTheme	gui/themes.cpp	/^void themes::setTheme(const QString& theme, int lang, QsciLexer* lexer, const QFont& fontt)$/;"	f	class:themes
+setTree	showgraph/Layout/aux_edge.h	/^    inline void setTree()$/;"	f	class:AuxEdge
+setType	showgraph/Layout/aux_edge.h	/^    inline void setType( AuxEdgeType t = UNKNOWN_TYPE_EDGE)$/;"	f	class:AuxEdge
+setType	showgraph/Layout/aux_node.h	/^    inline void setType( AuxNodeType t)$/;"	f	class:AuxNode
+setTypeEdgeControl	showgraph/Layout/aux_node.h	/^    inline void setTypeEdgeControl()$/;"	f	class:AuxNode
+setTypeEdgeLabel	showgraph/Layout/aux_node.h	/^    inline void setTypeEdgeLabel()$/;"	f	class:AuxNode
+setTypeSimple	showgraph/Layout/aux_node.h	/^    inline void setTypeSimple()$/;"	f	class:AuxNode
+setUnknown	showgraph/Layout/aux_edge.h	/^    inline void setUnknown()$/;"	f	class:AuxEdge
+setVal	showgraph/Utils/mem_utest.cpp	/^    void setVal( quint32 val)$/;"	f	class:MyPoolObj
+setWidth	showgraph/Layout/aux_node.h	/^    inline void setWidth( double w) $/;"	f	class:AuxNode
+setX	showgraph/Layout/aux_node.h	/^    inline void setX( double x)$/;"	f	class:AuxNode
+setY	showgraph/Layout/aux_graph.h	/^    inline void setY( qreal yy)$/;"	f	class:Level
+setY	showgraph/Layout/aux_node.h	/^    inline void setY( double y)$/;"	f	class:AuxNode
+set_header	makedb/csdbheader.cpp	/^void csdbheader::set_header(const char* hdr)$/;"	f	class:csdbheader
+set_header	makedb/csdbheader.cpp	/^void csdbheader::set_header(tStr hdr)$/;"	f	class:csdbheader
+setme	querylib/small_lib.cpp	/^void smartFILE::setme(FILE *fptr) {close_file(); m_fp = fptr;}$/;"	f	class:smartFILE
+setupGraphFromXML	gui/graphdialog.cpp	/^void cqDialogGraph::setupGraphFromXML(QString grpxml, QString grpdot, QString desc)$/;"	f	class:cqDialogGraph
+setup_CPP	gui/obsolete/highlighter.cpp	/^ void Highlighter::setup_CPP(void)$/;"	f	class:Highlighter
+setup_Java	gui/obsolete/highlighter.cpp	/^ void Highlighter::setup_Java(void)$/;"	f	class:Highlighter
+setup_Python	gui/obsolete/highlighter.cpp	/^ void Highlighter::setup_Python(void)$/;"	f	class:Highlighter
+setup_fileviewer	gui/mainwindow.cpp	/^void mainwindow::setup_fileviewer(void)$/;"	f	class:mainwindow
+setup_listhandler	gui/mainwindow.cpp	/^void mainwindow::setup_listhandler(void)$/;"	f	class:mainwindow
+setup_searchhandler	gui/mainwindow.cpp	/^void mainwindow::setup_searchhandler(void)$/;"	f	class:mainwindow
+setup_srcfil_read	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::setup_srcfil_read(void)$/;"	f	class:csdbparser
+setup_symbol_read	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::setup_symbol_read(void)$/;"	f	class:csdbparser
+setup_tables	makedb/cs2sq.cpp	/^cs2sq::enResult cs2sq::setup_tables(void)$/;"	f	class:cs2sq
+shape	showgraph/GraphView/edge_helper.cpp	/^EdgeHelper::shape() const$/;"	f	class:EdgeHelper
+shape	showgraph/GraphView/edge_item.cpp	/^EdgeItem::shape() const$/;"	f	class:EdgeItem
+shape	showgraph/GraphView/gstyle.h	/^inline NodeShape GStyle::shape() const$/;"	f	class:GStyle
+shape	showgraph/GraphView/node_item.cpp	/^NodeItem::shape() const$/;"	f	class:NodeItem
+shape2Path	showgraph/GraphView/node_item.cpp	/^shape2Path( NodeShape shape, QRectF rect)$/;"	f
+shape2Rect	showgraph/GraphView/node_item.cpp	/^shape2Rect( NodeShape shape, QRectF rect)$/;"	f
+shapeChanged	showgraph/GraphView/node_item.cpp	/^void NodeItem::shapeChanged()$/;"	f	class:NodeItem
+shape_combo	showgraph/GraphView/style_edit.h	/^    QComboBox *shape_combo;$/;"	m	class:StyleEdit
+shape_label	showgraph/GraphView/style_edit.h	/^    QLabel *shape_label;$/;"	m	class:StyleEdit
+shape_priv	showgraph/GraphView/gstyle.h	/^    NodeShape shape_priv;$/;"	m	class:GStyle
+shiftEdge	showgraph/Layout/layout.cpp	/^    void shiftEdge()$/;"	f	struct:DfsStepInfo
+shortName	showgraph/Utils/conf.h	/^    inline QString shortName() const$/;"	f	class:Option
+shortOption	showgraph/Utils/conf.h	/^    inline Option* shortOption( QString name)$/;"	f	class:Conf
+short_name	showgraph/Utils/conf.h	/^    QString short_name;$/;"	m	class:Option
+short_opts	showgraph/Utils/conf.h	/^    QHash< QString, Option *> short_opts;$/;"	m	class:Conf
+showEdgePred	showgraph/GraphView/graph_view.cpp	/^void GGraph::showEdgePred()$/;"	f	class:GGraph
+showEdgePred	showgraph/GraphView/graph_view.cpp	/^void GraphView::showEdgePred()$/;"	f	class:GraphView
+showEdgeSucc	showgraph/GraphView/graph_view.cpp	/^void GGraph::showEdgeSucc()$/;"	f	class:GGraph
+showEdgeSucc	showgraph/GraphView/graph_view.cpp	/^void GraphView::showEdgeSucc()$/;"	f	class:GraphView
+showEditEdgeStyle	showgraph/GraphView/graph_view.cpp	/^void GGraph::showEditEdgeStyle()$/;"	f	class:GGraph
+showEditEdgeStyle	showgraph/GraphView/graph_view.cpp	/^void GraphView::showEditEdgeStyle()$/;"	f	class:GraphView
+showEditEdgeStyleAct	showgraph/GraphView/graph_view.h	/^    QAction *showEditEdgeStyleAct;$/;"	m	class:GraphView
+showEditNodeStyle	showgraph/GraphView/graph_view.cpp	/^void GGraph::showEditNodeStyle()$/;"	f	class:GGraph
+showEditNodeStyle	showgraph/GraphView/graph_view.cpp	/^void GraphView::showEditNodeStyle()$/;"	f	class:GraphView
+showEditNodeStyleAct	showgraph/GraphView/graph_view.h	/^    QAction *showEditNodeStyleAct;$/;"	m	class:GraphView
+showHelper	showgraph/GraphView/graph_view.h	/^    inline void showHelper()$/;"	f	class:GraphView
+showNodeText	showgraph/GraphView/graph_view.h	/^    inline void showNodeText( GNode * n)$/;"	f	class:GraphView
+showNodesText	showgraph/GraphView/graph_view.cpp	/^void GGraph::showNodesText()$/;"	f	class:GGraph
+showPredAct	showgraph/GraphView/graph_view.h	/^    QAction *showPredAct;$/;"	m	class:GraphView
+showSelectedNodesText	showgraph/GraphView/graph_view.cpp	/^void GraphView::showSelectedNodesText()$/;"	f	class:GraphView
+showSuccAct	showgraph/GraphView/graph_view.h	/^    QAction *showSuccAct;$/;"	m	class:GraphView
+showTextAct	showgraph/GraphView/graph_view.h	/^    QAction *showTextAct;$/;"	m	class:GraphView
+showWholeGraph	showgraph/GraphView/graph_view.cpp	/^void GGraph::showWholeGraph()$/;"	f	class:GGraph
+show_menus	showgraph/GraphView/graph_view.h	/^    bool show_menus;$/;"	m	class:GraphView
+showgraph	showgraph/showgraph.cpp	/^showgraph::showgraph()$/;"	f	class:showgraph
+showgraph	showgraph/showgraph.h	/^class showgraph$/;"	c
+singleLineCommentFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat singleLineCommentFormat;$/;"	m	class:Highlighter
+single_line_symbol	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::single_line_symbol(bool& endOfSymbData, bool& foundSomething)$/;"	f	class:csdbparser
+singlequotationFormat	gui/obsolete/highlighter.h	/^     QTextCharFormat singlequotationFormat;$/;"	m	class:Highlighter
+size	querylib/small_lib.cpp	/^unsigned int tempbuf::size(void) const {return m_size;}$/;"	f	class:tempbuf
+sizeHint	gui/obsolete/CodeEditor.h	/^     QSize sizeHint() const {$/;"	f	class:LineNumberArea
+sizeHint	showgraph/GraphView/style_edit.cpp	/^QSize ColorButton::sizeHint() const$/;"	f	class:ColorButton
+smartFILE	querylib/small_lib.cpp	/^smartFILE::smartFILE() :m_fp(NULL) {}$/;"	f	class:smartFILE
+smartFILE	querylib/small_lib.cpp	/^smartFILE::smartFILE(FILE *fptr) :m_fp(fptr) {}$/;"	f	class:smartFILE
+smartFILE	querylib/small_lib.cpp	/^smartFILE::smartFILE(const smartFILE& sfp) :m_fp(sfp.m_fp) {}$/;"	f	class:smartFILE
+smartFILE	querylib/small_lib.h	/^class smartFILE$/;"	c
+smooth_focus	showgraph/GraphView/graph_view.h	/^    bool smooth_focus;$/;"	m	class:GraphView
+smooth_layout_adjustment	showgraph/GraphView/graph_view.h	/^    bool smooth_layout_adjustment;$/;"	m	class:GraphView
+sortNodesByOrder	showgraph/Layout/layout.cpp	/^void Level::sortNodesByOrder()$/;"	f	class:Level
+spacing	showgraph/Layout/aux_node.h	/^    inline qreal spacing( AuxNodeType prev_type) const$/;"	f	class:AuxNode
+splitCmdLine	gui/winmain.cpp	/^vector<string> splitCmdLine()$/;"	f
+splitstr	querylib/small_lib.cpp	/^std::vector<std::string> splitstr(const char* inpstr, const char delim)$/;"	f
+sq	gui/searchhandler.cpp	/^sqlqueryadv* searchhandler::sq = NULL;$/;"	m	class:searchhandler	file:
+sq	gui/searchhandler.h	/^static sqlqueryadv* sq;$/;"	m	class:searchhandler
+sqlbase	makedb/sqlbase.cpp	/^sqlbase::sqlbase()$/;"	f	class:sqlbase
+sqlbase	makedb/sqlbase.h	/^class sqlbase$/;"	c
+sqlerrmsg	querylib/sqlquery.h	/^	tStr sqlerrmsg;$/;"	m	class:sqlqueryresultlist
+sqlerrormsg	gui/searchhandler.cpp	/^QString searchhandler::sqlerrormsg(sqlquery::en_filereadstatus status)$/;"	f	class:searchhandler
+sqlfileINCORRECTVER	querylib/sqlquery.h	/^		sqlfileINCORRECTVER,$/;"	e	enum:sqlquery::en_filereadstatus
+sqlfileNOTCORRECTDB	querylib/sqlquery.h	/^		sqlfileNOTCORRECTDB,$/;"	e	enum:sqlquery::en_filereadstatus
+sqlfileOK	querylib/sqlquery.h	/^		sqlfileOK = 0,$/;"	e	enum:sqlquery::en_filereadstatus
+sqlfileOPENERROR	querylib/sqlquery.h	/^		sqlfileOPENERROR,$/;"	e	enum:sqlquery::en_filereadstatus
+sqlfileUNKNOWNERROR	querylib/sqlquery.h	/^		sqlfileUNKNOWNERROR$/;"	e	enum:sqlquery::en_filereadstatus
+sqlquery	querylib/sqlquery.cpp	/^sqlquery::sqlquery()$/;"	f	class:sqlquery
+sqlquery	querylib/sqlquery.h	/^class sqlquery$/;"	c
+sqlquerySYMBOL	querylib/sqlquery.h	/^		sqlquerySYMBOL = 0,$/;"	e	enum:sqlquery::en_queryType
+sqlqueryadv	gui/sqlqueryadv.cpp	/^sqlqueryadv::sqlqueryadv()$/;"	f	class:sqlqueryadv
+sqlqueryadv	gui/sqlqueryadv.h	/^class sqlqueryadv : public sqlquery$/;"	c
+sqlqueryresult	querylib/sqlquery.h	/^	sqlqueryresult() : linenum((const char*)"1"){}$/;"	f	class:sqlqueryresult
+sqlqueryresult	querylib/sqlquery.h	/^class sqlqueryresult$/;"	c
+sqlqueryresultlist	querylib/sqlquery.cpp	/^sqlqueryresultlist::sqlqueryresultlist()$/;"	f	class:sqlqueryresultlist
+sqlqueryresultlist	querylib/sqlquery.cpp	/^sqlqueryresultlist::sqlqueryresultlist(const sqlqueryresultlist& copy)$/;"	f	class:sqlqueryresultlist
+sqlqueryresultlist	querylib/sqlquery.h	/^class sqlqueryresultlist$/;"	c
+sqlresultAUTOCOMPLETE	querylib/sqlquery.h	/^		sqlresultAUTOCOMPLETE,$/;"	e	enum:sqlquery::en_queryType
+sqlresultCALLEDFUNC	querylib/sqlquery.h	/^		sqlresultCALLEDFUNC,$/;"	e	enum:sqlquery::en_queryType
+sqlresultCALLINGFUNC	querylib/sqlquery.h	/^		sqlresultCALLINGFUNC,$/;"	e	enum:sqlquery::en_queryType
+sqlresultCALLSOFFUNC	querylib/sqlquery.h	/^		sqlresultCALLSOFFUNC,$/;"	e	enum:sqlquery::en_queryType
+sqlresultCHILDCLASS	querylib/sqlquery.h	/^		sqlresultCHILDCLASS,$/;"	e	enum:sqlquery::en_queryType
+sqlresultCLASS_STRUCT	querylib/sqlquery.h	/^		sqlresultCLASS_STRUCT,$/;"	e	enum:sqlquery::en_queryType
+sqlresultDEFAULT	querylib/sqlquery.h	/^		sqlresultDEFAULT = 100$/;"	e	enum:sqlquery::en_queryType
+sqlresultERROR	querylib/sqlquery.h	/^		sqlresultERROR$/;"	e	enum:sqlqueryresultlist::en_resultType
+sqlresultFILEPATH	querylib/sqlquery.h	/^		sqlresultFILEPATH,$/;"	e	enum:sqlquery::en_queryType
+sqlresultFILE_LINE	querylib/sqlquery.h	/^		sqlresultFILE_LINE,$/;"	e	enum:sqlqueryresultlist::en_resultType
+sqlresultFILE_ONLY	querylib/sqlquery.h	/^		sqlresultFILE_ONLY,$/;"	e	enum:sqlqueryresultlist::en_resultType
+sqlresultFULL	querylib/sqlquery.h	/^		sqlresultFULL = 0,$/;"	e	enum:sqlqueryresultlist::en_resultType
+sqlresultFUNCSINFILE	querylib/sqlquery.h	/^		sqlresultFUNCSINFILE,$/;"	e	enum:sqlquery::en_queryType
+sqlresultFUNC_MACRO	querylib/sqlquery.h	/^		sqlresultFUNC_MACRO,$/;"	e	enum:sqlquery::en_queryType
+sqlresultGREP	querylib/sqlquery.h	/^		sqlresultGREP,$/;"	e	enum:sqlquery::en_queryType
+sqlresultINCLUDE	querylib/sqlquery.h	/^		sqlresultINCLUDE,$/;"	e	enum:sqlquery::en_queryType
+sqlresultMEMBERS	querylib/sqlquery.h	/^		sqlresultMEMBERS,$/;"	e	enum:sqlquery::en_queryType
+sqlresultOWNERCLASS	querylib/sqlquery.h	/^		sqlresultOWNERCLASS,$/;"	e	enum:sqlquery::en_queryType
+sqlresultPARENTCLASS	querylib/sqlquery.h	/^		sqlresultPARENTCLASS,$/;"	e	enum:sqlquery::en_queryType
+sqlresultSYM_ONLY	querylib/sqlquery.h	/^		sqlresultSYM_ONLY,$/;"	e	enum:sqlqueryresultlist::en_resultType
+src	showgraph/GraphView/edge_helper.h	/^EdgeHelper::src() const$/;"	f	class:EdgeHelper
+srcP	showgraph/GraphView/edge_helper.h	/^    QPointF srcP;$/;"	m	class:EdgeHelper
+srcP	showgraph/GraphView/edge_item.h	/^    QPointF srcP;$/;"	m	class:EdgeItem
+src_item	showgraph/GraphView/edge_helper.h	/^    NodeItem *src_item;$/;"	m	class:EdgeHelper
+stClsID	makedb/ctagread.h	/^} stClsID;$/;"	t	typeref:struct:__anon6
+stIDLE	makedb/csdbparser.h	/^   stIDLE = 0,$/;"	e	enum:csdbparser::enState
+stSYMB_SETUP_DONE	makedb/csdbparser.h	/^   stSYMB_SETUP_DONE$/;"	e	enum:csdbparser::enState
+stStrID	makedb/cs2sq.h	/^} stStrID;$/;"	t	typeref:struct:__anon4
+stable	showgraph/Layout/aux_node.h	/^    bool stable;$/;"	m	class:AuxNode
+startAnimationNodes	showgraph/GraphView/graph_view.cpp	/^void GraphView::startAnimationNodes()$/;"	f	class:GraphView
+state	showgraph/GraphView/edge_helper.h	/^    EdgeHelperState state;$/;"	m	class:EdgeHelper
+str	makedb/cs2sq.h	/^	std::string str;$/;"	m	struct:__anon4
+str2NodeShape	showgraph/GraphView/gstyle.h	/^str2NodeShape( const QString &str)$/;"	f
+str2qt	gui/std2qt.h	/^inline QString str2qt(const tStr& inp)$/;"	f
+strIDList	makedb/cs2sq.h	/^typedef std::vector<stStrID> strIDList;$/;"	t
+strLst2qt	gui/std2qt.cpp	/^QStringList strLst2qt(const tVecStr& inpLst)$/;"	f
+strctagIDList	makedb/ctagread.h	/^typedef std::vector<std::string> strctagIDList;$/;"	t
+string	showgraph/Utils/conf.h	/^    inline QString string() const$/;"	f	class:Option
+string_val	showgraph/Utils/conf.h	/^    QString string_val;$/;"	m	class:Option
+strrevcmp	querylib/small_lib.cpp	/^bool strrevcmp(tStr str, tStr cmpstr)$/;"	f
+strvect	makedb/csdbparser.h	/^typedef std::vector<std::string> strvect;$/;"	t
+style	showgraph/GraphView/edge_item.h	/^    inline GStyle * style() const$/;"	f	class:GEdge
+style	showgraph/GraphView/node_item.h	/^    inline GStyle * style() const$/;"	f	class:GNode
+styleEditFinished	showgraph/GraphView/graph_view.cpp	/^void GraphView::styleEditFinished( int result)$/;"	f	class:GraphView
+style_edit_info	showgraph/GraphView/graph_view.h	/^    StyleEditInfo *style_edit_info;$/;"	m	class:GraphView
+styleid	gui/themes.cpp	/^	int styleid;$/;"	m	struct:__anon2	file:
+styles	showgraph/GraphView/graph_view.h	/^    QHash< QString, GStyle *> styles;$/;"	m	class:GGraph
+succ	showgraph/Graph/agraph.h	/^    inline ANode *succ() const $/;"	f	class:AEdge
+succ	showgraph/Graph/edge_inline.h	/^inline Node *Edge::succ() const$/;"	f	class:Edge
+succ	showgraph/GraphView/edge_item.h	/^    inline GNode *succ() const $/;"	f	class:GEdge
+succ	showgraph/GraphView/edge_item.h	/^    inline GNode* succ() const$/;"	f	class:EdgeItem
+succ	showgraph/GraphView/visible_edge.h	/^GNode *VEdge::succ() const$/;"	f	class:VEdge
+succ	showgraph/Layout/aux_edge.h	/^    inline AuxNode *succ() const $/;"	f	class:AuxEdge
+succ_priv	showgraph/GraphView/visible_edge.h	/^    GNode *succ_priv;$/;"	m	class:VEdge
+succsBegin	showgraph/Graph/node_inline.h	/^inline Node::Succ Node::succsBegin()$/;"	f	class:Node
+succsEnd	showgraph/Graph/node_inline.h	/^inline Node::Succ Node::succsEnd()$/;"	f	class:Node
+switchToRegular	showgraph/GraphView/edge_helper.h	/^EdgeHelper::switchToRegular()$/;"	f	class:EdgeHelper
+symClass	makedb/csdbparser.h	/^   symClass,$/;"	e	enum:sym_data::enSymType
+symDrctAssgnIncrDecr	makedb/csdbparser.h	/^   symDrctAssgnIncrDecr,$/;"	e	enum:sym_data::enSymType
+symEnum	makedb/csdbparser.h	/^   symEnum,$/;"	e	enum:sym_data::enSymType
+symFile	makedb/csdbparser.h	/^   symFile$/;"	e	enum:sym_data::enSymType
+symFuncCall	makedb/csdbparser.h	/^   symFuncCall,$/;"	e	enum:sym_data::enSymType
+symFuncDef	makedb/csdbparser.h	/^   symFuncDef,$/;"	e	enum:sym_data::enSymType
+symFuncParam	makedb/csdbparser.h	/^   symFuncParam,$/;"	e	enum:sym_data::enSymType
+symGlobal	makedb/csdbparser.h	/^   symGlobal,$/;"	e	enum:sym_data::enSymType
+symGlobalEnumStructUnion	makedb/csdbparser.h	/^   symGlobalEnumStructUnion,$/;"	e	enum:sym_data::enSymType
+symIncl	makedb/csdbparser.h	/^   symIncl,$/;"	e	enum:sym_data::enSymType
+symLocalFuncBlockDef	makedb/csdbparser.h	/^   symLocalFuncBlockDef,$/;"	e	enum:sym_data::enSymType
+symMacroDef	makedb/csdbparser.h	/^   symMacroDef,$/;"	e	enum:sym_data::enSymType
+symNone	makedb/csdbparser.h	/^   symNone = 0,$/;"	e	enum:sym_data::enSymType
+symStruct	makedb/csdbparser.h	/^   symStruct,$/;"	e	enum:sym_data::enSymType
+symTypeDef	makedb/csdbparser.h	/^   symTypeDef,$/;"	e	enum:sym_data::enSymType
+symUnion	makedb/csdbparser.h	/^   symUnion,$/;"	e	enum:sym_data::enSymType
+sym_data	makedb/csdbparser.cpp	/^sym_data::sym_data()$/;"	f	class:sym_data
+sym_data	makedb/csdbparser.cpp	/^sym_data::sym_data(const sym_data& copy)$/;"	f	class:sym_data
+sym_data	makedb/csdbparser.h	/^class sym_data$/;"	c
+sym_type	makedb/csdbparser.h	/^enSymType sym_type;$/;"	m	class:sym_data
+symbname	makedb/csdbparser.h	/^std::string symbname;$/;"	m	class:sym_data
+symbname_escaped	makedb/csdbparser.cpp	/^std::string sym_data::symbname_escaped(void)$/;"	f	class:sym_data
+symbolread	makedb/csdbparser.cpp	/^csdbparser::enResult csdbparser::symbolread(sym_data *data, symdata_pack* pack)$/;"	f	class:csdbparser
+symbols	makedb/csdbparser.h	/^symdatalist symbols;$/;"	m	class:symdata_pack
+symbtypetbl	makedb/csdbparser.cpp	/^static const chr2enum symbtypetbl[] =$/;"	v	file:
+symbtypetbl_SIZE	makedb/csdbparser.cpp	/^#define symbtypetbl_SIZE /;"	d	file:
+symdata_pack	makedb/csdbparser.cpp	/^symdata_pack::symdata_pack()$/;"	f	class:symdata_pack
+symdata_pack	makedb/csdbparser.cpp	/^symdata_pack::symdata_pack(const symdata_pack& copy)$/;"	f	class:symdata_pack
+symdata_pack	makedb/csdbparser.h	/^class symdata_pack$/;"	c
+symdatalist	makedb/csdbparser.h	/^typedef std::vector<sym_data> symdatalist;$/;"	t
+symname	querylib/sqlquery.h	/^	tStr symname;$/;"	m	class:sqlqueryresult
+symtype	querylib/sqlquery.h	/^	tStr symtype;$/;"	m	class:sqlqueryresult
+tStr	querylib/small_lib.h	/^typedef std::string tStr;$/;"	t
+tVecStr	querylib/small_lib.h	/^typedef std::vector<std::string> tVecStr;$/;"	t
+tabWidthSelectionTemporary	gui/fileviewer.cpp	/^void fileviewer::tabWidthSelectionTemporary(const QString &width)$/;"	f	class:fileviewer
+tempbuf	querylib/small_lib.cpp	/^tempbuf::tempbuf(unsigned int n)$/;"	f	class:tempbuf
+tempbuf	querylib/small_lib.h	/^class tempbuf$/;"	c
+tempstmt	querylib/sqlquery.cpp	/^tempstmt::tempstmt()$/;"	f	class:tempstmt
+tempstmt	querylib/sqlquery.h	/^class tempstmt$/;"	c
+test	gui/obsolete/highlighter.cpp	/^void test(void)$/;"	f
+test_csdb	makedb/cs2sq.cpp	/^csdbparser::enResult cs2sq::test_csdb(void)$/;"	f	class:cs2sq
+textDock	showgraph/GraphView/node_item.h	/^	inline QDockWidget *textDock() const$/;"	f	class:NodeItem
+textRect	showgraph/GraphView/node_item.h	/^    inline QRectF textRect() const$/;"	f	class:NodeItem
+textSizeChange	gui/fileviewer.cpp	/^void fileviewer::textSizeChange(int n)$/;"	f	class:fileviewer
+text_dock	showgraph/GraphView/node_item.h	/^	QDockWidget *text_dock;$/;"	m	class:NodeItem
+text_shown	showgraph/GraphView/node_item.h	/^	bool text_shown;$/;"	m	class:GNode
+themeSelectionTemporary	gui/fileviewer.cpp	/^void fileviewer::themeSelectionTemporary(const QString &themetxt)$/;"	f	class:fileviewer
+themelist	gui/themes_gen.cpp	/^static const char* themelist[] = {$/;"	v	file:
+themename	gui/themes.cpp	/^	const char *themename;$/;"	m	struct:__anon3	file:
+themes	gui/themes.h	/^class themes$/;"	c
+timerEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::timerEvent( QTimerEvent *event)$/;"	f	class:GraphView
+timer_id	showgraph/GraphView/graph_view.h	/^    int timer_id;$/;"	m	class:GraphView
+tmpSrc	showgraph/GraphView/graph_view.h	/^    GNode *tmpSrc;$/;"	m	class:GraphView
+toBeDeleted	showgraph/Utils/mem_pool.h	/^        inline void toBeDeleted()$/;"	f	class:Mem::PoolObj
+toRegular	showgraph/GraphView/node_item.h	/^    inline void toRegular()$/;"	f	class:NodeItem
+to_be_deleted	showgraph/Utils/mem_pool.h	/^        bool to_be_deleted;$/;"	m	class:Mem::PoolObj
+toggleEditableAction	showgraph/GraphView/graph_view.h	/^    inline QAction* toggleEditableAction() const$/;"	f	class:GraphView
+toggleEdition	showgraph/GraphView/graph_view.cpp	/^void GraphView::toggleEdition( bool e)$/;"	f	class:GraphView
+toggleSmoothFocus	showgraph/GraphView/graph_view.cpp	/^void GraphView::toggleSmoothFocus( bool smooth)$/;"	f	class:GraphView
+toggleViewMode	showgraph/GraphView/graph_view.cpp	/^void GraphView::toggleViewMode( bool context)$/;"	f	class:GraphView
+toolTip	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::toolTip() const$/;"	f	class:CodeEditorWidgetPlugin
+topLeft	showgraph/GraphView/edge_helper.h	/^    QPointF topLeft;$/;"	m	class:EdgeHelper
+topLeft	showgraph/GraphView/edge_item.h	/^    QPointF topLeft;$/;"	m	class:EdgeItem
+translatedoc	gui/translations/dowebtranslate.pl	/^sub translatedoc$/;"	s
+type	makedb/csdbparser.cpp	/^sym_data::enSymType type;$/;"	m	struct:__anon5	file:
+type	showgraph/GraphView/edge_helper.h	/^inline int EdgeHelper::type() const$/;"	f	class:EdgeHelper
+type	showgraph/GraphView/edge_item.h	/^    int type() const$/;"	f	class:EdgeItem
+type	showgraph/GraphView/graph_view.h	/^    NavEventType type;$/;"	m	class:NavEvent
+type	showgraph/GraphView/node_item.h	/^    inline int type() const$/;"	f	class:NodeItem
+type	showgraph/Layout/aux_edge.h	/^	inline AuxEdgeType type() const$/;"	f	class:AuxEdge
+type	showgraph/Layout/aux_node.h	/^    inline AuxNodeType type() const$/;"	f	class:AuxNode
+type	showgraph/Utils/conf.h	/^    inline OptType type() const$/;"	f	class:Option
+uTestConf	showgraph/Utils/conf_utest.cpp	/^bool uTestConf()$/;"	f
+uTestList	showgraph/Utils/list_utest.cpp	/^bool uTestList()$/;"	f
+uTestMList	showgraph/Utils/list_utest.cpp	/^static bool uTestMList()$/;"	f	file:
+uTestMem	showgraph/Utils/mem_utest.cpp	/^bool uTestMem()$/;"	f
+uTestPools	showgraph/Utils/mem_utest.cpp	/^uTestPools()$/;"	f	file:
+uTestRef	showgraph/Utils/mem_utest.cpp	/^uTestRef()$/;"	f	file:
+uTestSingle	showgraph/Utils/utils_utest.cpp	/^bool uTestSingle()$/;"	f
+uTestUtils	showgraph/Utils/utils_utest.cpp	/^bool uTestUtils()$/;"	f
+ui	gui/mainwindow.h	/^Ui::MainWindow *ui;$/;"	m	class:mainwindow
+uid	showgraph/Graph/edge.h	/^    GraphUid uid; \/\/Unique ID$/;"	m	class:Edge
+uid	showgraph/Graph/node.h	/^    GraphUid uid;   \/**< Unique id        *\/$/;"	m	class:Node
+unNumber	showgraph/Graph/num.h	/^Numbered::unNumber( Numeration num)$/;"	f	class:Numbered
+unique_symnames	gui/sqlqueryadv.cpp	/^void sqlqueryadv::unique_symnames(sqlqueryresultlist& res)$/;"	f	class:sqlqueryadv
+unknownOptsNum	showgraph/Utils/conf.h	/^    inline int unknownOptsNum() const$/;"	f	class:Conf
+unknown_options	showgraph/Utils/conf.h	/^    QList< QString> unknown_options;$/;"	m	class:Conf
+unmark	showgraph/Graph/marker.h	/^inline bool Marked::unmark( Marker marker)$/;"	f	class:Marked
+updateAssociates	showgraph/GraphView/node_item.cpp	/^void NodeItem::updateAssociates()$/;"	f	class:NodeItem
+updateElement	showgraph/Graph/edge.cpp	/^Edge::updateElement()$/;"	f	class:Edge
+updateElement	showgraph/Graph/node_inline.h	/^Node::updateElement()$/;"	f	class:Node
+updateElement	showgraph/GraphView/edge_item.cpp	/^GEdge::updateElement()$/;"	f	class:GEdge
+updateElement	showgraph/GraphView/node_item.cpp	/^GNode::updateElement()$/;"	f	class:GNode
+updateFilePathLabel	gui/fileviewer.cpp	/^void fileviewer::updateFilePathLabel(void)$/;"	f	class:fileviewer
+updateFilterHistory	gui/searchhandler.cpp	/^void searchhandler::updateFilterHistory(QString filtertxt)$/;"	f	class:searchhandler
+updateLineNumberArea	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::updateLineNumberArea(const QRect &rect, int dy)$/;"	f	class:CodeEditor
+updateLineNumberAreaWidth	gui/obsolete/CodeEditor.cpp	/^ void CodeEditor::updateLineNumberAreaWidth(int \/* newBlockCount *\/)$/;"	f	class:CodeEditor
+updateList	gui/listhandler.cpp	/^void listhandler::updateList(void)$/;"	f	class:listhandler
+updateListHeaders	gui/listhandler.cpp	/^void listhandler::updateListHeaders(void)$/;"	f	class:listhandler
+updateListItemRowNum	gui/searchhandler.cpp	/^void searchhandler::updateListItemRowNum(const int& row)$/;"	f	class:searchhandler
+updateMatrix	showgraph/GraphView/graph_view.cpp	/^void GraphView::updateMatrix()$/;"	f	class:GraphView
+updateSearchHistory	gui/searchhandler.cpp	/^void searchhandler::updateSearchHistory(const QString& searchtxt)$/;"	f	class:searchhandler
+updateTextEdit	gui/fileviewer.cpp	/^void fileviewer::updateTextEdit(void)$/;"	f	class:fileviewer
+vacuum	makedb/sqlbase.cpp	/^int sqlbase::vacuum(const char* fn, const bool& debug)$/;"	f	class:sqlbase
+val	showgraph/Utils/mem_utest.cpp	/^    quint32 val() const$/;"	f	class:MyPoolObj
+valid	makedb/csdbparser.h	/^bool valid;$/;"	m	class:sym_data
+valid	makedb/csdbparser.h	/^bool valid;$/;"	m	class:symdata_pack
+validateRanking	showgraph/Layout/aux_graph.h	/^    inline void validateRanking()$/;"	f	class:AuxGraph
+value	showgraph/Graph/marker.h	/^    MarkerValue value;$/;"	m	class:Marker
+value	showgraph/Graph/num.h	/^    NumValue value;$/;"	m	class:Numeration
+values	showgraph/Utils/conf.h	/^    OptValues values;$/;"	m	class:Option
+view	showgraph/GraphView/graph_view.h	/^    inline GraphView *view() const$/;"	f	class:GGraph
+viewEvent	showgraph/GraphView/graph_view.cpp	/^void GraphViewHistory::viewEvent( NavEventType t, GNode *n)$/;"	f	class:GraphViewHistory
+viewHistory	showgraph/GraphView/graph_view.h	/^    inline GraphViewHistory * viewHistory() const$/;"	f	class:GraphView
+view_history	showgraph/GraphView/graph_view.h	/^    GraphViewHistory *view_history;$/;"	m	class:GraphView
+view_mode	showgraph/GraphView/graph_view.h	/^    GraphViewMode view_mode;$/;"	m	class:GraphView
+view_p	showgraph/GraphView/graph_view.h	/^    GraphView *view_p;$/;"	m	class:GGraph
+watcher	showgraph/Layout/aux_graph.h	/^    QFutureWatcher< void> *watcher;$/;"	m	class:AuxGraph
+weight	showgraph/Layout/node_group.h	/^    inline float weight() const$/;"	f	class:NodeGroup
+whatsThis	gui/obsolete/CodeEditorWidgetPlugin/CodeEditorWidgetPlugin.cpp	/^ QString CodeEditorWidgetPlugin::whatsThis() const$/;"	f	class:CodeEditorWidgetPlugin
+wheelEvent	showgraph/GraphView/graph_view.cpp	/^void GraphView::wheelEvent(QWheelEvent *event)$/;"	f	class:GraphView
+width	showgraph/GraphView/node_item.h	/^    virtual inline double width() const$/;"	f	class:GNode
+width	showgraph/Layout/aux_node.h	/^    virtual double width() const$/;"	f	class:AuxNode
+writeElement	showgraph/GraphView/gstyle.h	/^GStyle::writeElement( QDomElement e, bool save_name)$/;"	f	class:GStyle
+writeSettings	gui/mainwindow.cpp	/^void mainwindow::writeSettings()$/;"	f	class:mainwindow
+writeToXML	showgraph/Graph/graph.cpp	/^Graph::writeToXML( QString filename)$/;"	f	class:Graph
+writeToXML	showgraph/GraphView/graph_view.cpp	/^GGraph::writeToXML( QString filename)$/;"	f	class:GGraph
+y	showgraph/Layout/aux_graph.h	/^    inline qreal y() const$/;"	f	class:Level
+y_pos	showgraph/Layout/aux_graph.h	/^    qreal y_pos;$/;"	m	class:Level
+zeroLinks	showgraph/Utils/list.h	/^    inline void zeroLinks()$/;"	f	class:MListItem
+zoomIn	showgraph/GraphView/graph_view.cpp	/^void GraphView::zoomIn()$/;"	f	class:GraphView
+zoomOrig	showgraph/GraphView/graph_view.cpp	/^void GraphView::zoomOrig()$/;"	f	class:GraphView
+zoomOut	showgraph/GraphView/graph_view.cpp	/^void GraphView::zoomOut()$/;"	f	class:GraphView
+zoom_out_done	showgraph/GraphView/graph_view.h	/^    bool zoom_out_done;$/;"	m	class:GraphView
+zoom_scale	showgraph/GraphView/graph_view.h	/^    qreal zoom_scale;$/;"	m	class:GraphView
+zoomin	gui/graphdialog.cpp	/^void cqDialogGraph::zoomin()$/;"	f	class:cqDialogGraph
+zoomout	gui/graphdialog.cpp	/^void cqDialogGraph::zoomout()$/;"	f	class:cqDialogGraph
+~AuxGraph	showgraph/Layout/aux_graph.cpp	/^AuxGraph::~AuxGraph()$/;"	f	class:AuxGraph
+~AuxNode	showgraph/Layout/aux_graph.cpp	/^AuxNode::~AuxNode()$/;"	f	class:AuxNode
+~Conf	showgraph/Utils/conf.h	/^    ~Conf()$/;"	f	class:Conf
+~Edge	showgraph/Graph/edge.cpp	/^Edge::~Edge()$/;"	f	class:Edge
+~EdgeIterIface	showgraph/Graph/node_inline.h	/^inline EdgeIterIface< EdgeIterImpl>::~EdgeIterIface()$/;"	f	class:EdgeIterIface
+~Entry	showgraph/Utils/mem_entry.h	/^    Entry< Data>::~Entry()$/;"	f	class:MemImpl::Entry
+~FixedPool	showgraph/Utils/mem_fixed_pool.h	/^    FixedPool< Data>::~FixedPool()$/;"	f	class:Mem::FixedPool
+~GEdge	showgraph/GraphView/edge_item.cpp	/^GEdge::~GEdge()$/;"	f	class:GEdge
+~GGraph	showgraph/GraphView/graph_view.cpp	/^GGraph::~GGraph()$/;"	f	class:GGraph
+~GNode	showgraph/GraphView/node_item.cpp	/^GNode::~GNode()$/;"	f	class:GNode
+~GStyle	showgraph/GraphView/gstyle.h	/^    virtual ~GStyle(){};$/;"	f	class:GStyle
+~Graph	showgraph/Graph/graph.cpp	/^Graph::~Graph()$/;"	f	class:Graph
+~GraphView	showgraph/GraphView/graph_view.cpp	/^GraphView::~GraphView()$/;"	f	class:GraphView
+~GraphViewHistory	showgraph/GraphView/graph_view.h	/^    ~GraphViewHistory()$/;"	f	class:GraphViewHistory
+~ListItem	showgraph/Utils/list.h	/^    ~ListItem()$/;"	f	class:ListItem
+~MListItem	showgraph/Utils/list.h	/^    virtual ~MListItem()$/;"	f	class:MListItem
+~MemInfo	showgraph/Utils/mem_mgr.h	/^        ~MemInfo(){};$/;"	f	class:MemImpl::MemInfo
+~MyPoolObj	showgraph/Utils/mem_utest.cpp	/^    ~MyPoolObj()$/;"	f	class:MyPoolObj
+~Node	showgraph/Graph/node.cpp	/^Node::~Node()$/;"	f	class:Node
+~Obj	showgraph/Utils/mem_obj.h	/^		~Obj()$/;"	f	class:Mem::Obj
+~Pool	showgraph/Utils/mem_pool.h	/^        virtual ~Pool(){};$/;"	f	class:Mem::Pool
+~PoolObj	showgraph/Utils/mem_pool.h	/^        virtual ~PoolObj()$/;"	f	class:Mem::PoolObj
+~Ref	showgraph/Utils/mem_ref.h	/^		~Ref()$/;"	f	class:Mem::Ref
+~classA	showgraph/Utils/utils_utest.cpp	/^    ~classA(){};$/;"	f	class:classA	file:
+~cqDialogAbout	gui/aboutdialog.cpp	/^cqDialogAbout::~cqDialogAbout()$/;"	f	class:cqDialogAbout
+~cqDialogFileViewSettings	gui/fileviewsettingsdialog.cpp	/^cqDialogFileViewSettings::~cqDialogFileViewSettings()$/;"	f	class:cqDialogFileViewSettings
+~cqDialogGraph	gui/graphdialog.cpp	/^cqDialogGraph::~cqDialogGraph()$/;"	f	class:cqDialogGraph
+~cs2sq	makedb/cs2sq.cpp	/^cs2sq::~cs2sq()$/;"	f	class:cs2sq
+~csdbparser	makedb/csdbparser.cpp	/^csdbparser::~csdbparser()$/;"	f	class:csdbparser
+~ctagread	makedb/ctagread.cpp	/^ctagread::~ctagread()$/;"	f	class:ctagread
+~fileviewer	gui/fileviewer.cpp	/^fileviewer::~fileviewer()$/;"	f	class:fileviewer
+~idxcounter	querylib/small_lib.cpp	/^idxcounter::~idxcounter(){}$/;"	f	class:idxcounter
+~listhandler	gui/listhandler.cpp	/^listhandler::~listhandler()$/;"	f	class:listhandler
+~mainwindow	gui/mainwindow.cpp	/^mainwindow::~mainwindow()$/;"	f	class:mainwindow
+~searchhandler	gui/searchhandler.cpp	/^searchhandler::~searchhandler()$/;"	f	class:searchhandler
+~searchitem	gui/searchhandler.h	/^	~searchitem(){}$/;"	f	class:searchitem
+~showgraph	showgraph/showgraph.cpp	/^showgraph::~showgraph()$/;"	f	class:showgraph
+~smartFILE	querylib/small_lib.cpp	/^smartFILE::~smartFILE() {close_file();}$/;"	f	class:smartFILE
+~sqlbase	makedb/sqlbase.cpp	/^sqlbase::~sqlbase()$/;"	f	class:sqlbase
+~sqlquery	querylib/sqlquery.cpp	/^sqlquery::~sqlquery()$/;"	f	class:sqlquery
+~sqlqueryadv	gui/sqlqueryadv.cpp	/^sqlqueryadv::~sqlqueryadv()$/;"	f	class:sqlqueryadv
+~sym_data	makedb/csdbparser.h	/^~sym_data() { \/* nothing to do *\/ }$/;"	f	class:sym_data
+~symdata_pack	makedb/csdbparser.h	/^~symdata_pack() { \/* nothing to do *\/ }$/;"	f	class:symdata_pack
+~tempbuf	querylib/small_lib.cpp	/^tempbuf::~tempbuf()$/;"	f	class:tempbuf
+~tempstmt	querylib/sqlquery.cpp	/^tempstmt::~tempstmt()$/;"	f	class:tempstmt


### PR DESCRIPTION
This pull request is related to #16 and adds a `./test/cscope.out` and `./test/tags` files.
The goal is to enable installation test for `brew` package manager.

In order to keep `cscope.out` file small, it is generated only for this file: `./build/CMakeFiles/3.0.1/CompilerIdC/CMakeCCompilerId.c`.

If we generated `cscope.out` for the whole project it would be ~ 4.5Mb large!

With files in the project, after installation we can easily perform independent,
automated test, example:

```
# test generating the DB
$ cqmakedb -s ./test/codequery.db -c ./test/cscope.out -t ./test/tags -p
# test DB search
$ cqsearch -s ./test/codequery.db -t 'info_platform'
```
