### PR TITLE
fixes segv crash caused by double close of sqlite3 db. Fixes #39?

### DIFF
--- a/makedb/cs2sq.cpp
+++ b/makedb/cs2sq.cpp
@@ -104,6 +104,7 @@ cs2sq::enResult cs2sq::open_db(const char* sqldb)
 	if (rc != SQLITE_OK)
 	{
 		sqlite3_close(m_db);
+		m_db = 0;
 		return resFILE_ACCESS_ERR;
 	}
 	return resOK;
@@ -120,6 +121,7 @@ void cs2sq::close_db(void)
 	sqlite3_finalize(m_callstmt);
 	sqlite3_finalize(m_symstmt);
 	sqlite3_close(m_db);
+	m_db = 0;
 }
 
 cs2sq::enResult cs2sq::setup_tables(void)

--- a/makedb/ctagread.cpp
+++ b/makedb/ctagread.cpp
@@ -72,6 +72,7 @@ void ctagread::close_files(void)
 	fclose(f_tags);
 	f_tags = NULL;
 	sqlite3_close(m_db);
+	m_db = 0;
 }
 
 ctagread::enResult ctagread::prepare_cqdb(void)

--- a/makedb/sqlbase.cpp
+++ b/makedb/sqlbase.cpp
@@ -20,7 +20,9 @@ sqlbase::sqlbase()
 
 sqlbase::~sqlbase()
 {
-	sqlite3_close(m_db);
+	if (m_db)
+		sqlite3_close(m_db);
+	m_db = 0;
 }
 
 void sqlbase::setDebug(bool val)


### PR DESCRIPTION
**cqmakedb** crashed with a segmentation violation at the very end of it's run. 

Class ctagread has sqlbase for its base class, and the db is closed inside of the ctagread class.  The inherited member **m_db** is used here as the argument to the library function **sqlite3_close()**. When the ctagread instance goes out of scope, the base class destructor is eventually called and the base class calls **sqlite3_close()** one more time.  In my case, it was called with an invalid pointer, causing the segmentation violation.  I suspect this is the same bug described in #39 